### PR TITLE
Sign-Assembly function

### DIFF
--- a/Public/Sign-Assembly.ps1
+++ b/Public/Sign-Assembly.ps1
@@ -44,6 +44,9 @@ function Sign-Assembly {
   Add-ToHashTableIfNotNull $Headers -Key 'MoreInfoUrl' -Value $MoreInfoUrl
   Add-ToHashTableIfNotNull $Headers -Key 'ReCompressZip' -Value $ReCompressZip
 
+  Write-Verbose "Signing $AssemblyFilename using $Url"
+  $Headers.Keys | ForEach { Write-Verbose "`t $_`: $($Headers[$_])" }
+
   Invoke-WebRequest `
     -Uri $Url `
     -InFile $AssemblyFilename `

--- a/Public/Sign-Assembly.ps1
+++ b/Public/Sign-Assembly.ps1
@@ -31,9 +31,9 @@ function Sign-Assembly {
 
     [string] $FileType = 'Exe',
     [string] $ReCompressZip,
-    [string] $Certificate,
-    [string] $Description,
-    [string] $MoreInfoUrl
+    [string] $Certificate = 'Master',
+    [string] $Description = 'Red Gate Software Ltd.',
+    [string] $MoreInfoUrl = 'http://www.red-gate.com'
   )
 
   $Url = "http://$Server/Sign"

--- a/Public/Sign-Assembly.ps1
+++ b/Public/Sign-Assembly.ps1
@@ -1,0 +1,53 @@
+function Add-ToHashTableIfNotNull {
+  param(
+    [Parameter(Mandatory=$true)]
+    [HashTable] $HashTable,
+    [Parameter(Mandatory=$true)]
+    [string] $Key,
+    [string] $Value
+  )
+
+  if( $Value ) {
+    $HashTable.Add($Key, $Value)
+  }
+}
+
+<#
+.SYNOPSIS
+  Send an assembly to a webserver to be signed
+.DESCRIPTION
+  Send an assembly to a webserver to be digitally signed
+#>
+function Sign-Assembly {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory=$true)]
+    [string] $Server,
+
+    [Parameter(Mandatory=$true)]
+    [string] $AssemblyFilename,
+
+    [string] $FileType = 'Exe',
+    [string] $ReCompressZip,
+    [string] $Certificate,
+    [string] $Description,
+    [string] $MoreInfoUrl
+  )
+
+  $Url = "http://$Server/Sign"
+
+  $Headers = @{ 'FileType' =  $FileType };
+  Add-ToHashTableIfNotNull $Headers -Key 'Certificate' -Value $Certificate
+  Add-ToHashTableIfNotNull $Headers -Key 'Description' -Value $Description
+  Add-ToHashTableIfNotNull $Headers -Key 'MoreInfoUrl' -Value $MoreInfoUrl
+  Add-ToHashTableIfNotNull $Headers -Key 'ReCompressZip' -Value $ReCompressZip
+
+  Invoke-WebRequest `
+    -Uri $Url `
+    -InFile $AssemblyFilename `
+    -OutFile $AssemblyFilename `
+    -Method Post `
+    -ContentType 'binary/octet-stream' `
+    -Headers $Headers
+
+}

--- a/Public/Sign-Assembly.ps1
+++ b/Public/Sign-Assembly.ps1
@@ -21,9 +21,11 @@ function Add-ToHashTableIfNotNull {
 function Sign-Assembly {
   [CmdletBinding()]
   param(
+    # The name of the server doing the signing
     [Parameter(Mandatory=$true)]
     [string] $Server,
 
+    # The path to the assembly to be signed. This file will be updated.
     [Parameter(Mandatory=$true)]
     [string] $AssemblyFilename,
 

--- a/Public/Sign-Assembly.ps1
+++ b/Public/Sign-Assembly.ps1
@@ -21,9 +21,10 @@ function Add-ToHashTableIfNotNull {
 function Sign-Assembly {
   [CmdletBinding()]
   param(
-    # The name of the server doing the signing
+    # The base Url of the web service doing the signing
+    # e.g. https://myserver.com/ or http://myoverserver.org:1234/
     [Parameter(Mandatory=$true)]
-    [string] $Server,
+    [string] $ServerBaseUrl,
 
     # The path to the assembly to be signed. This file will be updated.
     [Parameter(Mandatory=$true)]
@@ -36,7 +37,7 @@ function Sign-Assembly {
     [string] $MoreInfoUrl = 'http://www.red-gate.com'
   )
 
-  $Url = "http://$Server/Sign"
+  $Url = "$ServerBaseUrl/Sign"
 
   $Headers = @{ 'FileType' =  $FileType };
   Add-ToHashTableIfNotNull $Headers -Key 'Certificate' -Value $Certificate


### PR DESCRIPTION
Sign-Assembly is a function to sends a compiled assembly to a webserver so that the assembly can be digitally signed.

FYI: @nyctef, @samblackburn, @ChrisLambrou feel free to start using it in your build scripts once this is merged :smile: 