### PR TITLE
Check help

### DIFF
--- a/Public/ConvertTo-ShellEscaped.ps1
+++ b/Public/ConvertTo-ShellEscaped.ps1
@@ -1,9 +1,6 @@
 #requires -Version 2
 
 <#
-        Author: Chris Lambrou
-        Copyright 2015, Red Gate Software Limited
-
         .SYNOPSIS
         Shell-escapes one or more strings for use in a command-line when starting a process.
 
@@ -24,6 +21,10 @@
         ConvertTo-ShellEscaped @('-path', 'C:\Program Files\', '-db', 'Data Source=local;Application Name="My app"')
 
         -path "C:\Program Files\\" -db "Data Source=local;Application Name=\"My app\""
+
+        .NOTES
+        Author: Chris Lambrou
+        Copyright 2015, Red Gate Software Limited
 #>
 function ConvertTo-ShellEscaped
 {
@@ -47,12 +48,12 @@ function ConvertTo-ShellEscaped
         $Escaped = $QuotesWithPossibleLeadingBackslashes.Replace($_, {
                 param($Match) (New-Object string @('\', (2 * $Match.Value.Length - 1))) + '"'
         })
-    
+
         # If the string ends with one or more trailing backslashes, we need to double them up.
         $Escaped = $TrailingBackslashes.Replace($Escaped, {
                 param($Match) New-Object string @('\', (2 * $Match.Value.Length))
         })
-    
+
         # Finally, surround with quotes if necessary, because:
         # 1. The string is empty.
         # 2. Some escaping actually happened in the above replacement calls.

--- a/Public/Install-DotCoverPackage.ps1
+++ b/Public/Install-DotCoverPackage.ps1
@@ -1,6 +1,8 @@
 <#
 .SYNOPSIS
   Install JetBrains.dotCover.CommandLineTools to RedGate.Build\packages
+.DESCRIPTION
+  Install the JetBrains.dotCover.CommandLineTools nuget package to RedGate.Build\packages
 #>
 function Install-DotCoverPackage {
   [CmdletBinding()]

--- a/Public/Install-NUnitPackage.ps1
+++ b/Public/Install-NUnitPackage.ps1
@@ -1,6 +1,8 @@
 <#
 .SYNOPSIS
   Install NUnit.Runners to RedGate.Build\packages
+.DESCRIPTION
+  Install the NUnit.Runners nuget package to RedGate.Build\packages
 #>
 function Install-NUnitPackage {
   [CmdletBinding()]

--- a/Public/Install-Package.ps1
+++ b/Public/Install-Package.ps1
@@ -8,8 +8,10 @@
 function Install-Package {
   [CmdletBinding()]
   param(
+    # The name/id of the nuget package to install
     [Parameter(Mandatory=$true)]
     [string] $Name,
+    # The version of the nuget package to install
     [Parameter(Mandatory=$true)]
     [string] $Version
   )

--- a/Public/Install-SmartAssemblyPackage.ps1
+++ b/Public/Install-SmartAssemblyPackage.ps1
@@ -1,6 +1,8 @@
 <#
 .SYNOPSIS
   Install SmartAssembly to RedGate.Build\packages
+.DESCRIPTION
+  Install a nuget package containing SmartAssembly.com to RedGate.Build\packages
 #>
 function Install-SmartAssemblyPackage {
   [CmdletBinding()]

--- a/Public/New-NuGetPackageVersion.ps1
+++ b/Public/New-NuGetPackageVersion.ps1
@@ -7,7 +7,7 @@
     .DESCRIPTION
     Obtains a NuGet package version based on a 4-digit build version number, the branch name and whether or not the branch is the default branch.
 
-    .OUTPUT
+    .OUTPUTS
     A NuGet version string based on the input parameters. The string is also suitable for use as an assembly's AssemblyInformationalVersion attribute value.
 
     .EXAMPLE
@@ -20,28 +20,19 @@
 
     Returns '1.2.3-SomeBranch4'. This shows how this cmdlet might be invoked on a feature branch, resulting in a pre-release version string.
 #>
-function New-NuGetPackageVersion 
+function New-NuGetPackageVersion
 {
     [CmdletBinding()]
     param(
-        <#
-            .PARAMETER Version
-            A four digit version number of the form Major.Minor.Patch.Revision.
-        #>
+        # A four digit version number of the form Major.Minor.Patch.Revision.
         [Parameter(Mandatory = $true)]
         [version] $Version,
 
-        <#
-            .PARAMETER BranchName
-            The name of the current source control branch. e.g. 'master' or 'my-feature'. This is only used when IsDefaultBranch is false, in order to determine the pre-release version suffix. If the branch name is too long, this cmdlet will try to shorten it to satisfy the 20 character limit for the pre-release suffix. Nonetheless, you should try to avoid long branch names.
-        #>
+        # The name of the current source control branch. e.g. 'master' or 'my-feature'. This is only used when IsDefaultBranch is false, in order to determine the pre-release version suffix. If the branch name is too long, this cmdlet will try to shorten it to satisfy the 20 character limit for the pre-release suffix. Nonetheless, you should try to avoid long branch names.
         [Parameter(Mandatory = $true)]
         [string] $BranchName,
 
-        <#
-            .PARAMETER IsDefaultBranch
-            Indicates whether or not BranchName represents the default branch for the source control system currently in use. Please note that this is not a switch parameter - you must specify this value explicitly.
-        #>
+        # Indicates whether or not BranchName represents the default branch for the source control system currently in use. Please note that this is not a switch parameter - you must specify this value explicitly.
         [Parameter(Mandatory = $true)]
         [bool] $IsDefaultBranch
     )
@@ -65,12 +56,12 @@ function New-NuGetPackageVersion
     # Shorten the suffix if necessary, to satisfy NuGet's 20 character limit.
     $Revision = [string]$Version.Revision
     $MaxLength = 20 - $Revision.Length
-    if ($PreReleaseSuffix.Length -gt $MaxLength) 
+    if ($PreReleaseSuffix.Length -gt $MaxLength)
     {
         $PreReleaseSuffix = $PreReleaseSuffix -replace '[aeiou]', ''
 
         # If the suffix is still too long after we've stripped out the vovels, truncate it.
-        if ($PreReleaseSuffix.Length -gt $MaxLength) 
+        if ($PreReleaseSuffix.Length -gt $MaxLength)
         {
             $PreReleaseSuffix = $PreReleaseSuffix.Substring(0, $MaxLength)
         }

--- a/Public/New-TempDir.ps1
+++ b/Public/New-TempDir.ps1
@@ -1,4 +1,3 @@
-#requires -Version 1
 <#
         .SYNOPSIS
         Creates a new empty temp directory.

--- a/Public/Tests/Test-NugetPackagesVersionsAreConsistent.ps1
+++ b/Public/Tests/Test-NugetPackagesVersionsAreConsistent.ps1
@@ -24,6 +24,10 @@ function Test-NugetPackagesVersionsAreConsistent {
     [Parameter(ParameterSetName='FromConfigFiles', Mandatory = $True, Position = 0)]
     [string[]] $PackagesConfigPaths,
 
+    # A list of nuget packages.
+    # They should be pscustomobjects with 2 properties.
+    #   id:       the nuget package id
+    #   version:  the nuget package version
     [Parameter(ParameterSetName='FromPackageList', Mandatory = $True, Position = 0)]
     [pscustomobject[]] $NugetPackages
   )

--- a/Tests/PowershellHelp.Tests.ps1
+++ b/Tests/PowershellHelp.Tests.ps1
@@ -1,0 +1,33 @@
+#requires -Version 4 -Modules Pester
+
+# An Amazing test that will check that every function exported by this module does
+# indeed have its Powershell help well defined.
+Describe 'All exported functions help should be defined' {
+
+  Get-Command -Module RedGate.Build | where { $_.Name -notlike 'TeamCity-*'} | ForEach {
+    $command = $_
+    Context "Command $($command.Name)" {
+
+      $help = Get-Help $command.Name
+
+      It 'should have a synopsis' {
+        $help.Synopsis | Should Not BeNullOrEmpty
+        $help.Synopsis.Trim() | Should Not Be $command.Name
+      }
+      It 'should have a description' {
+        $help.Description | Should Not BeNullOrEmpty
+      }
+
+      if($help.parameters.parameter) {
+        $help.parameters.parameter | ForEach {
+          $param = $_
+          It "should have a description for parameter $($param.Name)" {
+            $param.Description | Should Not BeNullOrEmpty
+          }
+        }
+      }
+
+    }
+  }
+
+}

--- a/build.ps1
+++ b/build.ps1
@@ -28,7 +28,7 @@ param(
 
   [Parameter(Mandatory = $False)]
   [string] $NugetFeedToPublishTo,
-  
+
   [Parameter(Mandatory = $False)]
   [string] $NugetFeedApiKey
 )
@@ -54,7 +54,7 @@ try {
     # let TC know
     TeamCity-SetBuildNumber($Version)
   }
-  
+
   # Clean any previous build output.
   Write-Info 'Cleaning any prior build output'
   $NuGetPackagePath = ".\RedGate.Build.$Version.nupkg"
@@ -111,8 +111,8 @@ try {
 
   # Import the RedGate.Build module.
   Write-Info 'Importing the RedGate.Build module'
-  Import-Module .\RedGate.Build.psm1
-  
+  Import-Module .\RedGate.Build.psm1 -Force
+
   # Run Pester tests.
   Write-Info 'Running Pester tests'
   Invoke-Pester -Script .\Tests\ -OutputFile $PesterResultsPath -OutputFormat NUnitXml
@@ -134,7 +134,7 @@ try {
   } else {
     Write-Host 'Publish skipped'
   }
-  
+
   Write-Info 'Build completed'
 } finally {
   Pop-Location


### PR DESCRIPTION
New `Tests/PowershellHelp.Tests.ps`1 is using Pester to check that every function exported by `RedGate.Build` does have a minimal amount of help that is available for end users.

Currently checks for:
* For each function:
 * synopsis
 * description
* For each parameter:
 * description

The test will fail if any function is missing one or more of those...

Also fixed the functions for which the test failed. (did catch a couple of functions where the help was not available / properly parsed by Powershell ) :triumph: 
