### PR TITLE
Before importing code coverage results in Teamcity, let Teamcity know…

### DIFF
--- a/Public/Merge-CoverageReports.ps1
+++ b/Public/Merge-CoverageReports.ps1
@@ -28,6 +28,8 @@ function Merge-CoverageReports {
     # Create an HTML report if running outside of Teamcity to help with debugging
     & $DotCoverPath report /Source="$MergedSnapshotPath.zip" /Output="$OutputDir\report.html" /reporttype=HTML
   } else {
+    # Let Teamcity know where the current dotcover.exe we are using is
+    TeamCity-ConfigureDotNetCoverage -key 'dotcover_home' -value ($DotCoverPath | Split-Path)
     # Let Teamcity know where the report is.
     TeamCity-ImportDotNetCoverageResult 'dotcover' "$MergedSnapshotPath.zip"
   }


### PR DESCRIPTION
… where the current dotcover.exe we are using is

instead of letting Teamcity use its own (different?) version.

This might (not?) solve some issues where Teamcity is using dotcover 3.1 to import coverage reports while we are generating these reports using dotcover 3.2 :expressionless: