### PR TITLE
new function Test-ScriptForParsingErrors

### DIFF
--- a/Public/Tests/Test-ScriptForParsingErrors.ps1
+++ b/Public/Tests/Test-ScriptForParsingErrors.ps1
@@ -1,0 +1,43 @@
+<#
+.SYNOPSIS
+    Test a powershell script for parsing errors
+
+.DESCRIPTION
+    Parse a powershell script (without executing it) and throws parsing exceptions if any
+
+.EXAMPLE
+    Test-ScriptForParsingErrors -Path C:\myscript.ps1
+    Will parse C:\myscript.ps1 and throw exceptions if parsing errors are encountered.
+
+.EXAMPLE
+    'C:\myscript.ps1' | Test-ScriptForParsingErrors
+    Will parse C:\myscript.ps1 and throw exceptions if parsing errors are encountered.
+
+.EXAMPLE
+    dir '*.ps1' | Test-ScriptForParsingErrors
+    Will parse every powershell script in the current folder and throw exceptions if parsing errors are encountered.
+
+.LINK
+    To other relevant cmdlets or help
+#>
+Function Test-ScriptForParsingErrors
+{
+    [CmdletBinding()]
+    [OutputType([Nullable])]
+    Param
+    (
+        # The Path to the powershell script that will be tested
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName, Position=0)]
+        [String] $Path
+    )
+    Begin
+    {
+        $local:ErrorActionPreference = 'Stop'
+    }
+    Process
+    {
+        Write-Verbose "Parsing $Path to check for parsing error"
+        $ExecutionContext.InvokeCommand.NewScriptBlock((Get-Content -Path $Path | Out-String)) | Out-Null
+        Write-Verbose "Parsing $Path - All good!"
+    }
+}

--- a/Tests/Tests/Test-ScriptForParsingErrors.Tests.ps1
+++ b/Tests/Tests/Test-ScriptForParsingErrors.Tests.ps1
@@ -1,0 +1,33 @@
+#requires -Version 4 -Modules Pester
+
+Describe 'Test-ScriptForParsingErrors' {
+
+    Context 'When a script has no error' {
+
+        Mock -ModuleName RedGate.Build Get-Content {
+            return @(
+                '$i = 1',
+                '$i++',
+                'throw "this is a test error"'
+            )
+        } -ParameterFilter {$Path -eq 'script.ps1'}
+
+        It 'should not throw any exception' {
+            {Test-ScriptForParsingErrors -Path 'script.ps1'} | Should Not Throw
+        }
+    }
+
+    Context 'When a script cannot be parsed' {
+
+        Mock -ModuleName RedGate.Build Get-Content {
+            return @(
+                '$i=;',
+                'throw "this is a test error"'
+            )
+        } -ParameterFilter {$Path -eq 'script.ps1'}
+
+        It 'should rethrow any parsing exception' {
+            {Test-ScriptForParsingErrors -Path 'script.ps1'} | Should Throw "You must provide a value expression following the '=' operator."
+        }
+    }
+}


### PR DESCRIPTION
Test-ScriptForParsingErrors can be useful to check the syntax of Invoke-Build scripts before trying to run them and getting obscure `A parameter cannot be found that matches parameter name 'xxx'` messages....