### PR TITLE
Ability to sign files using sha256

### DIFF
--- a/Public/Invoke-SigningService.ps1
+++ b/Public/Invoke-SigningService.ps1
@@ -58,7 +58,11 @@ function Invoke-SigningService {
 
         # An optional URL that can be used to specify more information about the signed assembly by end-users. Defaults to 'http://www.red-gate.com'.
         [Parameter(Mandatory = $False)]
-        [string] $MoreInfoUrl = 'http://www.red-gate.com'
+        [string] $MoreInfoUrl = 'http://www.red-gate.com',
+
+        # If present, do not skip signing the file if it is already signed.
+        # If the file is already signed, do resign it.
+        [switch] $Force
     )
     begin {
         Get-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState -Name 'VerbosePreference', 'ProgressPreference'
@@ -74,7 +78,7 @@ function Invoke-SigningService {
         }
 
         # Only sign the file if it does not already have a valid Authenticode signature
-        if((Get-AuthenticodeSignature $FilePath).Status -eq 'Valid') {
+        if(!$Force.IsPresent -and (Get-AuthenticodeSignature $FilePath).Status -eq 'Valid') {
             Write-Verbose "Skipping signing $FilePath. It is already signed"
             return $FilePath
         }

--- a/Public/Invoke-SigningService.ps1
+++ b/Public/Invoke-SigningService.ps1
@@ -1,17 +1,3 @@
-function Add-ToHashTableIfNotNull {
-    param(
-        [Parameter(Mandatory=$true)]
-        [HashTable] $HashTable,
-        [Parameter(Mandatory=$true)]
-        [string] $Key,
-        [string] $Value
-    )
-
-    if( $Value ) {
-        $HashTable.Add($Key, $Value)
-    }
-}
-
 <#
     .SYNOPSIS
     Signs a .NET assembly, jar file, VSIX installer or ClickOnce application.
@@ -125,5 +111,19 @@ function Invoke-SigningService {
         # TODO: How should we check the response? Need to fail if the signing failed.
 
         return $FilePath
+    }
+}
+
+function Add-ToHashTableIfNotNull {
+    param(
+        [Parameter(Mandatory=$true)]
+        [HashTable] $HashTable,
+        [Parameter(Mandatory=$true)]
+        [string] $Key,
+        [string] $Value
+    )
+
+    if( $Value ) {
+        $HashTable.Add($Key, $Value)
     }
 }

--- a/Public/Invoke-SigningService.ps1
+++ b/Public/Invoke-SigningService.ps1
@@ -38,11 +38,15 @@ function Invoke-SigningService {
         [Parameter(Mandatory = $False)]
         [string] $Certificate = 'Master',
 
-        # Only used when signing vsix files. Valid values are sha1, sha256.
-        # For vsix targeting Visual Studio up to 2013, it should be sha1
-        # For vsix targeting Visual Studio 2015+, it should be sha256
-        # Note that it does not seem to be recommended to target VS 2013 and 2015 with the same vsix file
-        # Altough using sha1 in that case still seem to allow for the package to be installed in VS2015
+        # Algorithm used when signing files. Valid values are sha1, sha256.
+        # For vsix files:
+        #   if targeting Visual Studio up to 2013, it should be sha1
+        #   if targeting Visual Studio 2015+, it should be sha256
+        #   Note that it does not seem to be recommended to target VS 2013 and 2015 with the same vsix file...
+        # All other file types:
+        #   Recommendation is to use sha256 (as of 1 Jan 2016, IE flags sha1 as invalid signature)
+        #   Sha1 remains available, as it might remain useful for older OSes ?
+        #
         # Default value: sha1
         [Parameter(Mandatory = $False)]
         [ValidateSet('sha1', 'sha256')]
@@ -93,9 +97,7 @@ function Invoke-SigningService {
         Add-ToHashTableIfNotNull $Headers -Key 'Certificate' -Value $Certificate
         Add-ToHashTableIfNotNull $Headers -Key 'Description' -Value $Description
         Add-ToHashTableIfNotNull $Headers -Key 'MoreInfoUrl' -Value $MoreInfoUrl
-        if( $FileType -eq 'Vsix') {
-            Add-ToHashTableIfNotNull $Headers -Key 'HashAlgorithm' -Value $HashAlgorithm
-        }
+        Add-ToHashTableIfNotNull $Headers -Key 'HashAlgorithm' -Value $HashAlgorithm
 
         Write-Verbose "Signing $FilePath using $SigningServiceUrl"
         $Headers.Keys | ForEach { Write-Verbose "`t $_`: $($Headers[$_])" }

--- a/Public/Invoke-SigningService.ps1
+++ b/Public/Invoke-SigningService.ps1
@@ -47,10 +47,10 @@ function Invoke-SigningService {
         #   Recommendation is to use sha256 (as of 1 Jan 2016, IE flags sha1 as invalid signature)
         #   Sha1 remains available, as it might remain useful for older OSes ?
         #
-        # Default value: sha1
+        # Default value: sha256
         [Parameter(Mandatory = $False)]
         [ValidateSet('sha1', 'sha256')]
-        [string] $HashAlgorithm = 'sha1',
+        [string] $HashAlgorithm = 'sha256',
 
         # An optional description. Defaults to 'Red Gate Software Ltd.'.
         [Parameter(Mandatory = $False)]


### PR DESCRIPTION
* `Invoke-SigningService` has a new `-HashAlgorithm` parameter:
 * can take 2 values. `sha1` and `sha256`. `sha256` is selected by default.
* `Invoke-SigningService` has a new `-Force` parameter:
 * can be used to force re-signing files that have already been signed.