### PR TITLE
Prevent "Unsupported file type" error

### DIFF
--- a/Public/Invoke-SigningService.ps1
+++ b/Public/Invoke-SigningService.ps1
@@ -112,6 +112,7 @@ Use sha1 if targeting VS 2013 and older. Use sha256 if targeting VS 2015+
             }
             '.jar' { $FileType = 'Jar' }
             '.application' { $FileType = 'ClickOnce' }
+            '.manifest' { $fileType = 'ClickOnce' }
             default { throw "Unsupported file type: $FilePath" }
         }
 


### PR DESCRIPTION
...when signing a ClickOnce manifest.
This is currently preventing us from using Redgate.Build to sign our ClickOnce installer.
Tested in that it doesn't crash on my machine.