### PR TITLE
Do not publish dotcover snapshot file (*.coverage.snap)

### DIFF
--- a/Public/Invoke-NUnitForAssembly.ps1
+++ b/Public/Invoke-NUnitForAssembly.ps1
@@ -88,8 +88,7 @@ function Invoke-NUnitForAssembly {
 
     # Tell teamcity to keep our test output logs as well. This could come in handy
     $assemblyFilename = Split-Path $AssemblyPath -Leaf
-    TeamCity-PublishArtifact "$AssemblyPath.$TestResultFilenamePattern.* => logs/tests/$assemblyFilename.$TestResultFilenamePattern/logs.zip"
-    TeamCity-PublishArtifact "-:$AssemblyPath.$TestResultFilenamePattern.coverage.snap" # Do not ever package the dotcover snapshot (it can be quite big)
+    TeamCity-PublishArtifact "$AssemblyPath.$TestResultFilenamePattern.*.txt, $AssemblyPath.$TestResultFilenamePattern.*.xml => logs/tests/$assemblyFilename.$TestResultFilenamePattern/logs.zip"
   }
 
 }

--- a/Public/Invoke-NUnitForAssembly.ps1
+++ b/Public/Invoke-NUnitForAssembly.ps1
@@ -88,6 +88,7 @@ function Invoke-NUnitForAssembly {
 
     # Tell teamcity to keep our test output logs as well. This could come in handy
     $assemblyFilename = Split-Path $AssemblyPath -Leaf
+    TeamCity-PublishArtifact "-:$AssemblyPath.$TestResultFilenamePattern.coverage.snap" # Do not ever package the dotcover snapshot (it can be quite big)
     TeamCity-PublishArtifact "$AssemblyPath.$TestResultFilenamePattern.* => logs/tests/$assemblyFilename.$TestResultFilenamePattern/logs.zip"
   }
 

--- a/Public/Invoke-NUnitForAssembly.ps1
+++ b/Public/Invoke-NUnitForAssembly.ps1
@@ -88,7 +88,8 @@ function Invoke-NUnitForAssembly {
 
     # Tell teamcity to keep our test output logs as well. This could come in handy
     $assemblyFilename = Split-Path $AssemblyPath -Leaf
-    # $AssemblyPath.$TestResultFilenamePattern.*x* ? That's a horrible to only get the .xml and .txt file in 1 line.
+    # $AssemblyPath.$TestResultFilenamePattern.*x* ? That's a horrible way to only get the .xml and .txt file in 1 line.
+    # (and skip the *.coverage.snap file if any)
     # Teamcity doesn't seem to let you add files to an existing zipped file.... oh well...
     TeamCity-PublishArtifact "$AssemblyPath.$TestResultFilenamePattern.*x* => logs/tests/$assemblyFilename.$TestResultFilenamePattern/logs.zip"
   }

--- a/Public/Invoke-NUnitForAssembly.ps1
+++ b/Public/Invoke-NUnitForAssembly.ps1
@@ -88,9 +88,9 @@ function Invoke-NUnitForAssembly {
 
     # Tell teamcity to keep our test output logs as well. This could come in handy
     $assemblyFilename = Split-Path $AssemblyPath -Leaf
-    # $AssemblyPath.$TestResultFilenamePattern.*.*x* ? That's a horrible to only get the .xml and .txt file in 1 line.
+    # $AssemblyPath.$TestResultFilenamePattern.*x* ? That's a horrible to only get the .xml and .txt file in 1 line.
     # Teamcity doesn't seem to let you add files to an existing zipped file.... oh well...
-    TeamCity-PublishArtifact "$AssemblyPath.$TestResultFilenamePattern.*.*x* => logs/tests/$assemblyFilename.$TestResultFilenamePattern/logs.zip"
+    TeamCity-PublishArtifact "$AssemblyPath.$TestResultFilenamePattern.*x* => logs/tests/$assemblyFilename.$TestResultFilenamePattern/logs.zip"
   }
 
 }

--- a/Public/Invoke-NUnitForAssembly.ps1
+++ b/Public/Invoke-NUnitForAssembly.ps1
@@ -88,7 +88,9 @@ function Invoke-NUnitForAssembly {
 
     # Tell teamcity to keep our test output logs as well. This could come in handy
     $assemblyFilename = Split-Path $AssemblyPath -Leaf
-    TeamCity-PublishArtifact "$AssemblyPath.$TestResultFilenamePattern.*.txt => logs/tests/$assemblyFilename.$TestResultFilenamePattern/logs.zip, $AssemblyPath.$TestResultFilenamePattern.*.xml => logs/tests/$assemblyFilename.$TestResultFilenamePattern/logs.zip"
+    # $AssemblyPath.$TestResultFilenamePattern.*.*x* ? That's a horrible to only get the .xml and .txt file in 1 line.
+    # Teamcity doesn't seem to let you add files to an existing zipped file.... oh well...
+    TeamCity-PublishArtifact "$AssemblyPath.$TestResultFilenamePattern.*.*x* => logs/tests/$assemblyFilename.$TestResultFilenamePattern/logs.zip"
   }
 
 }

--- a/Public/Invoke-NUnitForAssembly.ps1
+++ b/Public/Invoke-NUnitForAssembly.ps1
@@ -88,8 +88,8 @@ function Invoke-NUnitForAssembly {
 
     # Tell teamcity to keep our test output logs as well. This could come in handy
     $assemblyFilename = Split-Path $AssemblyPath -Leaf
-    TeamCity-PublishArtifact "-:$AssemblyPath.$TestResultFilenamePattern.coverage.snap" # Do not ever package the dotcover snapshot (it can be quite big)
     TeamCity-PublishArtifact "$AssemblyPath.$TestResultFilenamePattern.* => logs/tests/$assemblyFilename.$TestResultFilenamePattern/logs.zip"
+    TeamCity-PublishArtifact "-:$AssemblyPath.$TestResultFilenamePattern.coverage.snap" # Do not ever package the dotcover snapshot (it can be quite big)
   }
 
 }

--- a/Public/Invoke-NUnitForAssembly.ps1
+++ b/Public/Invoke-NUnitForAssembly.ps1
@@ -88,7 +88,7 @@ function Invoke-NUnitForAssembly {
 
     # Tell teamcity to keep our test output logs as well. This could come in handy
     $assemblyFilename = Split-Path $AssemblyPath -Leaf
-    TeamCity-PublishArtifact "$AssemblyPath.$TestResultFilenamePattern.*.txt, $AssemblyPath.$TestResultFilenamePattern.*.xml => logs/tests/$assemblyFilename.$TestResultFilenamePattern/logs.zip"
+    TeamCity-PublishArtifact "$AssemblyPath.$TestResultFilenamePattern.*.txt => logs/tests/$assemblyFilename.$TestResultFilenamePattern/logs.zip, $AssemblyPath.$TestResultFilenamePattern.*.xml => logs/tests/$assemblyFilename.$TestResultFilenamePattern/logs.zip"
   }
 
 }


### PR DESCRIPTION
that will have to do :disappointed_relieved: 