### PR TITLE
Update New-NuGetPackageVersion

### DIFF
--- a/Public/New-NuGetPackageVersion.ps1
+++ b/Public/New-NuGetPackageVersion.ps1
@@ -48,8 +48,8 @@ function New-NuGetPackageVersion
     }
 
     # Otherwise establish the pre-release suffix from the branch name.
-    $PreReleaseSuffix = "-$BranchName"
-
+    $PreReleaseSuffix = $BranchName
+    
     # Remove invalid characters from the suffix.
     $PreReleaseSuffix = $PreReleaseSuffix -replace '[/]', '-'
     $PreReleaseSuffix = $PreReleaseSuffix -replace '[^0-9A-Za-z-]', ''
@@ -61,6 +61,6 @@ function New-NuGetPackageVersion
     $Major = $Version.Major
     $Minor = $Version.Minor
     $Patch = $Version.Build
-    $Revision = [string]$Version.Revision
-    return "$Major.$Minor.$Patch.$Revision$PreReleaseSuffix"
+    $Revision = $Version.Revision
+    return "$Major.$Minor.$Patch.$Revision-$PreReleaseSuffix"
 }

--- a/Public/New-NuGetPackageVersion.ps1
+++ b/Public/New-NuGetPackageVersion.ps1
@@ -51,25 +51,16 @@ function New-NuGetPackageVersion
     $PreReleaseSuffix = "-$BranchName"
 
     # Remove invalid characters from the suffix.
+    $PreReleaseSuffix = $PreReleaseSuffix -replace '[/]', '-'
     $PreReleaseSuffix = $PreReleaseSuffix -replace '[^0-9A-Za-z-]', ''
 
     # Shorten the suffix if necessary, to satisfy NuGet's 20 character limit.
-    $Revision = [string]$Version.Revision
-    $MaxLength = 20 - $Revision.Length
-    if ($PreReleaseSuffix.Length -gt $MaxLength)
-    {
-        $PreReleaseSuffix = $PreReleaseSuffix -replace '[aeiou]', ''
-
-        # If the suffix is still too long after we've stripped out the vovels, truncate it.
-        if ($PreReleaseSuffix.Length -gt $MaxLength)
-        {
-            $PreReleaseSuffix = $PreReleaseSuffix.Substring(0, $MaxLength)
-        }
-    }
+    $PreReleaseSuffix = $PreReleaseSuffix.SubString(0, [math]::min(20, $PreReleaseSuffix.Length))
 
     # And finally compose the full NuGet package version.
     $Major = $Version.Major
     $Minor = $Version.Minor
     $Patch = $Version.Build
-    return "$Major.$Minor.$Patch$PreReleaseSuffix$Revision"
+    $Revision = [string]$Version.Revision
+    return "$Major.$Minor.$Patch.$Revision$PreReleaseSuffix"
 }

--- a/Tests/New-NuGetPackageVersion.Tests.ps1
+++ b/Tests/New-NuGetPackageVersion.Tests.ps1
@@ -10,14 +10,17 @@ Describe 'New-NuGetPackageVersion' {
         it 'should throw when BranchName is empty' {
             { New-NuGetPackageVersion -Version '1.2.3.4' -IsDefaultBranch $False -BranchName '' } | Should Throw
         }
-        it 'should use the BranchName and revision number as the pre-release suffix' {
-            New-NuGetPackageVersion -Version '1.2.3.4' -IsDefaultBranch $False -BranchName 'SomeBranch' | Should Be '1.2.3-SomeBranch4'
+        it 'should use the BranchName without the revision number as the pre-release suffix' {
+            New-NuGetPackageVersion -Version '1.2.3.4' -IsDefaultBranch $False -BranchName 'SomeBranch' | Should Be '1.2.3.4-SomeBranch'
         }
-        it 'should shorten the pre-release suffix (by removing vowels) if the BranchName is too long' {
-            New-NuGetPackageVersion -Version '1.2.3.4' -IsDefaultBranch $False -BranchName 'SomeBranchNameThatsTooLong' | Should Be '1.2.3-SmBrnchNmThtsTLng4'
+        it 'should shorten the pre-release suffix (by truncating) if the BranchName is too long' {
+            New-NuGetPackageVersion -Version '1.2.3.4' -IsDefaultBranch $False -BranchName 'SomeBranchNameThatsTooLong' | Should Be '1.2.3.4-SomeBranchNameThats'
         }
-        it 'should shorten the pre-release suffix (by removing vowels and then truncating) if the BranchName is too long' {
-            New-NuGetPackageVersion -Version '1.2.3.4' -IsDefaultBranch $False -BranchName 'SomeBranchNameThatsReallyFarTooLong' | Should Be '1.2.3-SmBrnchNmThtsRllyF4'
+        it 'should replace "/" in the pre-release suffix by "-"' {
+            New-NuGetPackageVersion -Version '1.2.3.4' -IsDefaultBranch $False -BranchName 'build/fixing-it' | Should Be '1.2.3.4-build-fixing-it'
+        }
+        it 'should remove invalid characters from the pre-release suffix' {
+            New-NuGetPackageVersion -Version '1.2.3.4' -IsDefaultBranch $False -BranchName 'invalid\\$%£/chars;+=_' | Should Be '1.2.3.4-invalid-chars'
         }
     }
 }

--- a/Tests/New-NuGetPackageVersion.Tests.ps1
+++ b/Tests/New-NuGetPackageVersion.Tests.ps1
@@ -14,7 +14,7 @@ Describe 'New-NuGetPackageVersion' {
             New-NuGetPackageVersion -Version '1.2.3.4' -IsDefaultBranch $False -BranchName 'SomeBranch' | Should Be '1.2.3.4-SomeBranch'
         }
         it 'should shorten the pre-release suffix (by truncating) if the BranchName is too long' {
-            New-NuGetPackageVersion -Version '1.2.3.4' -IsDefaultBranch $False -BranchName 'SomeBranchNameThatsTooLong' | Should Be '1.2.3.4-SomeBranchNameThats'
+            New-NuGetPackageVersion -Version '1.2.3.4' -IsDefaultBranch $False -BranchName 'SomeBranchNameThatsTooLong' | Should Be '1.2.3.4-SomeBranchNameThatsT'
         }
         it 'should replace "/" in the pre-release suffix by "-"' {
             New-NuGetPackageVersion -Version '1.2.3.4' -IsDefaultBranch $False -BranchName 'build/fixing-it' | Should Be '1.2.3.4-build-fixing-it'


### PR DESCRIPTION
do not remove vowels when truncating. Just truncate.

And stick with the 4 part version number and stay away from Semver 1.0 for now.
 * `1.2.3.4`
 * `1.2.3.4-prerelease-string`

instead of
 * `1.2.3.4`
 * `1.2.3-prerelease-string4`

We can revisit this when nuget.exe and nuget server start supporting Semver 2.0