### PR TITLE
Create temporary folders within the RedGate.Build module folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.exe
 Pester
 TestResults.xml
+.temp/

--- a/Private/_Init.ps1
+++ b/Private/_Init.ps1
@@ -4,6 +4,7 @@
 # Create the packages folder where nuget packages used by this module will be installed.
 $PackagesDir = New-Item -Path "$PSScriptRoot\..\packages" -ItemType Directory -Force
 
+$TempFolderPath = New-Item "$PSScriptRoot\..\.temp" -ItemType Directory -Force | Select -ExpandProperty FullName
 
 # Store the path to nuget.exe.
 $NugetExe = Resolve-Path "$PSScriptRoot\nuget.exe"

--- a/Public/New-TempDir.ps1
+++ b/Public/New-TempDir.ps1
@@ -6,9 +6,9 @@
 .OUTPUTS
   The path of the newly created temporary directory.
 #>
-function New-TempDir 
+function New-TempDir
 {
-    $Path = "$env:TEMP\RedGate.Build\$([System.IO.Path]::GetRandomFileName())"
+    $Path = "$TempFolderPath\$([System.IO.Path]::GetRandomFileName())"
     Write-Verbose "Creating temp dir: $Path"
     return [string] (mkdir $Path)
 }

--- a/Tests/New-TempDir.Tests.ps1
+++ b/Tests/New-TempDir.Tests.ps1
@@ -2,17 +2,15 @@
 
 Describe 'New-TempDir' {
 
-    AfterAll {
-        if (Test-Path "$env:Temp\RedGate.Build") {
-            Remove-Item "$env:Temp\RedGate.Build" -Force -Recurse
-        }
-    }
-
     Context 'A newly created temporary directory' {
         $TempDir = New-TempDir
 
         It 'should exist' {
             $TempDir | Should Exist
+        }
+
+        It 'should contain \.temp\' {
+            $TempDir | Should Match '\\\.temp\\'
         }
     }
 }


### PR DESCRIPTION
This is an attempt at speeding up zipping files using New-ZipArchive.
(It turns out that zipping files from %TEMP% is causing our antivirus to interfere and slow things down...)

So create temporary folders in `RedGate.Build\.temp` instead