### PR TITLE
Fix Issue 26 - Install-Package copes with version differences

### DIFF
--- a/Public/Install-Package.ps1
+++ b/Public/Install-Package.ps1
@@ -1,29 +1,52 @@
 <#
-.SYNOPSIS
-  Install a Nuget Package to the RedGate.Build\packages\ folder
-.DESCRIPTION
-  Install a Nuget Package to the RedGate.Build\packages folder
-  and return the full path of the folder where the package was extracted to.
+        .SYNOPSIS
+        Install a Nuget Package to the RedGate.Build\packages\ folder.
+        .DESCRIPTION
+        Install a Nuget Package to the RedGate.Build\packages folder
+        and return a DirectoryInfo object for the full path of the folder
+        where the package was extracted to.
+        .PARAMETER Name
+        The name/id of the nuget package to install.
+        .PARAMETER Version
+        The version of the nuget package to install.
+        .OUTPUTS
+        A DirectoryInfo object that represents the folder that the package
+        was installed to.
 #>
-function Install-Package {
-  [CmdletBinding()]
-  param(
-    # The name/id of the nuget package to install
-    [Parameter(Mandatory=$true)]
-    [string] $Name,
-    # The version of the nuget package to install
-    [Parameter(Mandatory=$true)]
-    [string] $Version
-  )
+#requires -Version 2
+function Install-Package 
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Name,
 
-  if( -not(Test-Path "$PackagesDir\$Name.$Version")) {
-    # Install the package (only if not already there). Print any nuget.exe output to the verbose stream
-    Write-Verbose "Installing $Name.$Version to $PackagesDir" -verbose
-    Execute-Command -ScriptBlock {
-      & $NugetExe install $Name -Version $Version -OutputDirectory $PackagesDir -PackageSaveMode nuspec | Write-Verbose
+        [Parameter(Mandatory = $true)]
+        [string] $Version
+    )
+
+    # Looks for an existing package that matches the requested id and version.
+    if (Test-Path $PackagesDir) {
+        $ExistingPackageDirs = Get-ChildItem -Path $PackagesDir -Directory `
+        | Where-Object { $_.Name.StartsWith("$Name.$Version", 'InvariantCultureIgnoreCase') } `
+        | Sort-Object -Descending { $_.Name }
+        if ($ExistingPackageDirs.Length -gt 0) {
+            return $ExistingPackageDirs[0]
+        }
     }
-  }
 
-  # Return the folder where the package was installed
-  "$PackagesDir\$Name.$Version" | Resolve-Path
+    # Install the package (only if not already there). Print any nuget.exe output to the verbose stream
+    Write-Verbose "Installing $Name.$Version to $PackagesDir" -Verbose
+    Execute-Command -ScriptBlock {
+        & $NugetExe install $Name -Version $Version -OutputDirectory $PackagesDir -PackageSaveMode nuspec | Write-Verbose
+    }
+
+    # Now search once again for the newly installed package.
+    $ExistingPackageDirs = Get-ChildItem -Path $PackagesDir -Directory `
+    | Where-Object { $_.Name.StartsWith("$Name.$Version", 'InvariantCultureIgnoreCase') } `
+    | Sort-Object -Descending { $_.Name }
+    if ($ExistingPackageDirs.Length -eq 0) {
+        throw 'Failed to locate the folder of the newly installed package'
+    }
+    return $ExistingPackageDirs[0]
 }


### PR DESCRIPTION
`Install-Package` now copes with the possibility that NuGet might not install the precise version that was requested. e.g. if version 1.2.3 is asked for, NuGet may actually install version 1.2.3.4.

The solution is to allow NuGet to do it's thing, then scan the packages folder to see what was actually installed, and return the correct folder, rather than guessing the folder based solely on the package id and requested version.