### PR TITLE
Added Install-NodeJsPackage cmdlet.

### DIFF
--- a/Private/_Init.ps1
+++ b/Private/_Init.ps1
@@ -12,6 +12,7 @@ $NugetExe = Resolve-Path "$PSScriptRoot\nuget.exe"
 $DefaultNUnitVersion = '2.6.4'
 $DefaultDotCoverVersion = '3.2.0'
 $DefaultSmartAssemblyVersion = '6.8.0.248'
+$DefaultNodeJsPackageVersion = '6.0.0'
 
 
 if ($Host.Name -eq "Default Host") {

--- a/Public/Install-NodeJsPackage.ps1
+++ b/Public/Install-NodeJsPackage.ps1
@@ -1,0 +1,50 @@
+<#
+        .SYNOPSIS
+        Installs a working copy of nodejs and npm.
+        .DESCRIPTION
+        Installs the RedGate.ThirdParty.NodeJs package to RedGate.Build\packages,
+        unpacks nodejs to C:\Tools\NodeJs\x.x.x, and then returns an object with
+        properties that represent paths to the nodejs dir, node.exe and npm.cmd.
+        .PARAMETER Version
+        The full 4-digit version number of the version of the
+        RedGate.ThirdParty.NodeJs package that provides nodejs. You may also
+        specify a 3-digit version of nodejs, as long as there is indeed an available
+        associated version of the RedGate.ThirdParty.NodeJs package.
+        The minimum supported version number is 6.0.0.
+        .OUTPUTS
+        An object that contains the following properties:
+        - NodeJsVersion [string]: The actual installed version number of nodejs
+        - NodeJsDir [string]: The location of the nodejs installation folder.
+        - NodeExePath [string]: The path of the node.exe binary.
+        - NpmCmdPath [string]: The path of the npm.cmd command.
+#>
+#requires -Version 2
+function Install-NodeJsPackage 
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $False, Position = 0)]
+        [string] $Version = $DefaultNodeJsPackageVersion
+    )
+
+    # First install the package
+    Write-Verbose 'Installing RedGate.ThirdParty.NodeJs'
+    $PackagePath = (Install-Package RedGate.ThirdParty.NodeJs $Version).FullName
+  
+    # Now unpack nodejs from the package.
+    Write-Verbose 'Extracting nodejs'
+    $InstallScriptPath = "$PackagePath\tools\install.ps1"
+    $NodeJsDir = & "$InstallScriptPath"
+    if ($NodeJsDir.EndsWith('\')) {
+        $NodeJsDir = $NodeJsDir.Substring(0, $NodeJsDir.Length - 1)
+    }
+    Write-Verbose "nodejs directory = $NodeJsDir"
+
+    # Craft the result.
+    return @{
+        NodeJsVersion = $NodeJsDir.Substring(1 + $NodeJsDir.LastIndexOf('\'));
+        NodeJsDir = $NodeJsDir;
+        NodeExePath = "$NodeJsDir\node.exe";
+        NpmCmdPath = "$NodeJsDir\npm.cmd"
+    }
+}


### PR DESCRIPTION
This provides a new cmdlet, `Install-NodeJsPackage`, which will install nodejs using the `RedGate.ThirdParty.NodeJs` package, returning an object with the following string properties:

``` PowerShell
@{
    NodeJsVersion = '6.0.0'; # The installed version of nodejs.
    NodeJsDir = 'C:\Tools\NodeJs\6.0.0'; # The folder nodejs was unpacked to.
    NodeExePath = 'C:\Tools\NodeJs\6.0.0\node.exe'; # The full path of node.exe.
    NpmCmdPath = 'C:\Tools\NodeJs\6.0.0\npm.cmd'; # The full path of npm.cmd.
}
```

You could use it as follows:

``` PowerShell
$NodeExePath = (Install-NodeJsPackage6.0.0).NodeExePath
```

Note that the `RedGate.ThirdParty.NodeJs` is not yet available in the public nuget.org package source. Hopefully that will happen after some internal testing. Meanwhile, current users of this cmdlet will have to make sure that the internal Redgate package source is specified in their local `NuGet.config`.
