### PR TITLE
Add support for dotCover attribute filters

### DIFF
--- a/Public/Invoke-DotCoverForExecutable.ps1
+++ b/Public/Invoke-DotCoverForExecutable.ps1
@@ -31,7 +31,7 @@ function Invoke-DotCoverForExecutable {
 
     [Parameter(Mandatory = $False)]
     [Alias('DotCoverFilters')]
-    [string] $Filters = ''
+    [string] $Filters = '',
 
     [Parameter(Mandatory = $False)]
     [string] $AttributeFilters = ''

--- a/Public/Invoke-DotCoverForExecutable.ps1
+++ b/Public/Invoke-DotCoverForExecutable.ps1
@@ -11,8 +11,10 @@
   The output XML file containing the detailed coverage information.
 .PARAMETER DotCoverVersion
   The version of dotCover nuget package to use.
-.PARAMETER DotCoverFilters
+.PARAMETER Filters
   Coverage filters for dotCover, to indicate what should and should not be covered.
+.PARAMETER AttributeFilters
+  Attribute coverage filters for dotCover, to indicate what should and should not be covered.
 #>
 function Invoke-DotCoverForExecutable {
   [CmdletBinding()]

--- a/Public/Invoke-DotCoverForExecutable.ps1
+++ b/Public/Invoke-DotCoverForExecutable.ps1
@@ -30,7 +30,11 @@ function Invoke-DotCoverForExecutable {
     [string] $DotCoverVersion = $DefaultDotCoverVersion,
 
     [Parameter(Mandatory = $False)]
-    [string] $DotCoverFilters = ''
+    [Alias('DotCoverFilters')]
+    [string] $Filters = ''
+
+    [Parameter(Mandatory = $False)]
+    [string] $AttributeFilters = ''
   )
 
   $DotCoverArguments = @(
@@ -40,8 +44,12 @@ function Invoke-DotCoverForExecutable {
     '/ReturnTargetExitCode'
   )
 
-  if (![string]::IsNullOrWhiteSpace($DotCoverFilters)) {
-    $DotCoverArguments += "/Filters=$DotCoverFilters"
+  if (![string]::IsNullOrWhiteSpace($Filters)) {
+    $DotCoverArguments += "/Filters=$Filters"
+  }
+
+  if (![string]::IsNullOrWhiteSpace($AttributeFilters)) {
+    $DotCoverArguments += "/AttributeFilters=$AttributeFilters"
   }
 
   if ($TargetArguments) {

--- a/Public/Invoke-NUnitForAssembly.ps1
+++ b/Public/Invoke-NUnitForAssembly.ps1
@@ -42,6 +42,8 @@ function Invoke-NUnitForAssembly {
     [string] $DotCoverVersion = $DefaultDotCoverVersion,
     # The dotcover filters passed to dotcover.exe
     [string] $DotCoverFilters = '',
+    # The dotcover filters passed to dotcover.exe
+    [string] $DotCoverAttributeFilters = '',
     # If set, do not import test results automatically to Teamcity.
     # In this case it is the responsibility of the caller to call 'TeamCity-ImportNUnitReport "$AssemblyPath.$TestResultFilenamePattern.xml"'
     [switch] $DotNotImportResultsToTeamcity
@@ -71,7 +73,8 @@ function Invoke-NUnitForAssembly {
         -TargetArguments $NunitArguments `
         -OutputFile "$AssemblyPath.$TestResultFilenamePattern.coverage.snap" `
         -DotCoverVersion $DotCoverVersion `
-        -DotCoverFilters $DotCoverFilters
+        -Filters $DotCoverFilters `
+        -AttributeFilters $DotCoverAttributeFilters
 
     } else {
 


### PR DESCRIPTION
This adds support for dotCover's attribute filters to `Invoke-DotCoverForExecutable` and `Invoke-NUnitForAssembly`.