### PR TITLE
The console exe moved packages for 3.0.0.0+

### DIFF
--- a/Private/NUnit.ps1
+++ b/Private/NUnit.ps1
@@ -45,11 +45,19 @@ function Get-NUnitConsoleExePath {
         #By default, use nunit-console.exe
         [switch] $x86
     )
-
-    $nunitExec = 'nunit-console.exe'
+	
+	$nunitBase = 'nunit'
+	if (!$NUnitVersion.StartsWith("2.")) {
+		# Version 3 puts the major version in front, let's assume that's a trend
+		$nunitBase += $NUnitVersion.Split(".")[0]
+	}
+	
+	$nunitConsole = '-console'
     if($x86.IsPresent) {
-        $nunitExec = 'nunit-console-x86.exe'
-    }
+        $nunitConsole += '-x86'
+    }	
+	
+    $nunitExec = $nunitBase + $nunitConsole + '.exe'
 
     Write-Verbose "Using NUnit version $NUnitVersion"
     $NUnitFolder = Install-NUnitPackage $NUnitVersion

--- a/Private/NUnit.ps1
+++ b/Private/NUnit.ps1
@@ -55,8 +55,10 @@ function Get-NUnitConsoleExePath {
         # The version of the nuget package containing the NUnit executables (NUnit.Runners)
         [string] $NUnitVersion = $DefaultNUnitVersion,
 
-        #If set, return path to nunit-console-x86.exe.
-        #By default, use nunit-console.exe
+        # If set, return path to nunit-console-x86.exe.
+        # By default, use nunit-console.exe.
+        # Note that this will not do anything if -NUnitVersion is 3+.
+        # That's because there is not nunit3-console-x86.exe. (instead nunit3-console.exe takes a --x86 parameter)
         [switch] $x86
     )
 
@@ -67,7 +69,7 @@ function Get-NUnitConsoleExePath {
 	}
 
 	$nunitConsole = '-console'
-    if($x86.IsPresent) {
+    if($x86.IsPresent -and $NUnitVersion.StartsWith("2.")) {
         $nunitConsole += '-x86'
     }
 

--- a/Private/NUnit.ps1
+++ b/Private/NUnit.ps1
@@ -5,13 +5,16 @@ function Build-NUnitCommandLineArguments {
         [string] $AssemblyPath,
         [Parameter(Mandatory=$true)]
         [string] $NUnitVersion,
+        [bool] $x86,
         [string] $FrameworkVersion,
         [string[]] $ExcludedCategories = @(),
         [string[]] $IncludedCategories = @(),
         [string] $TestResultFilenamePattern = 'TestResult'
     )
 
-    if($NUnitVersion.StartsWith("2.")){
+    $IsNunit2 = $NUnitVersion.StartsWith("2.")
+
+    if($IsNunit2){
         $paramPrefix = "/"
     } else {
         $paramPrefix = "--"
@@ -22,7 +25,7 @@ function Build-NUnitCommandLineArguments {
         "$($paramPrefix)out=`"$AssemblyPath.$TestResultFilenamePattern.TestOutput.txt`"",
         "$($paramPrefix)err=`"$AssemblyPath.$TestResultFilenamePattern.TestError.txt`""
 
-    if($NUnitVersion.StartsWith("2.")) {
+    if($IsNunit2) {
         $params += '/nologo',
         '/nodots',
         '/noshadow',
@@ -30,6 +33,11 @@ function Build-NUnitCommandLineArguments {
     } else {
         $params += '--noheader',
             '--labels=On'
+    }
+
+    if($x86 -and !$IsNunit2) {
+        #NUnit 3+ takes a --x86 parameter
+        $params += '--x86'
     }
 
     if($FrameworkVersion) {

--- a/Public/Install-NUnitPackage.ps1
+++ b/Public/Install-NUnitPackage.ps1
@@ -10,6 +10,10 @@ function Install-NUnitPackage {
     # The version of the nuget package containing the NUnit executables (NUnit.Runners)
     [string] $Version = $DefaultNUnitVersion
   )
-
-  Install-Package NUnit.Runners $Version
+ 
+  $packageName = "NUnit.Console" #Contains exe from 3.0 onwards
+  if ($Version.StartsWith("2.")) {
+    $packageName = "NUnit.Runners"
+  }
+  Install-Package $packageName $Version
 }

--- a/Public/Invoke-NUnitForAssembly.ps1
+++ b/Public/Invoke-NUnitForAssembly.ps1
@@ -60,6 +60,7 @@ function Invoke-NUnitForAssembly {
     $NunitArguments = Build-NUnitCommandLineArguments `
       -AssemblyPath $AssemblyPath `
       -NUnitVersion $NUnitVersion `
+      -x86 $x86.IsPresent `
       -FrameworkVersion $FrameworkVersion `
       -ExcludedCategories $ExcludedCategories `
       -IncludedCategories $IncludedCategories `

--- a/Public/Invoke-NUnitForAssembly.ps1
+++ b/Public/Invoke-NUnitForAssembly.ps1
@@ -59,6 +59,7 @@ function Invoke-NUnitForAssembly {
 
     $NunitArguments = Build-NUnitCommandLineArguments `
       -AssemblyPath $AssemblyPath `
+      -NUnitVersion $NUnitVersion `
       -FrameworkVersion $FrameworkVersion `
       -ExcludedCategories $ExcludedCategories `
       -IncludedCategories $IncludedCategories `

--- a/Public/Merge-CoverageReports.ps1
+++ b/Public/Merge-CoverageReports.ps1
@@ -22,7 +22,8 @@ function Merge-CoverageReports {
   $DotCoverPath = Get-DotCoverExePath
 
   $MergedSnapshotPath = "$OutputDir\coverage.dcvr"
-  $snapshots = (Get-ChildItem $OutputDir -Filter *.coverage.snap -Recurse:$Recurse.IsPresent).FullName
+  # Use -ErrorAction SilentlyContinue to survive windows "path is too long" errors.
+  $snapshots = (Get-ChildItem $OutputDir -Filter *.coverage.snap -Recurse:$Recurse.IsPresent -ErrorAction SilentlyContinue).FullName
   Write-Verbose "Merging snapshots: `r`n$snapshots`r`n`r`nto $MergedSnapshotPath"
 
   & $DotCoverPath merge /Source="$($snapshots -join ';')" /Output="$MergedSnapshotPath"

--- a/Public/Merge-CoverageReports.ps1
+++ b/Public/Merge-CoverageReports.ps1
@@ -13,24 +13,33 @@ function Merge-CoverageReports {
   param(
     # The folder containing the coverage reports to be merged.
     [Parameter(Mandatory=$true)]
-    [string] $OutputDir,
+    [Alias('OutputDir')]
+    [string] $SnapshotsDir,
 
     # Also find coverage reports in child folders.
-    [switch] $Recurse
+    [switch] $Recurse,
+
+    # The folder where the merged coverage report will be saved.
+    # If not set, this will default to the value of -SnapshotsDir
+    [string] $CoverageOutputFolder
   )
+
+  if(!$CoverageOutputFolder) {
+      $CoverageOutputFolder = $SnapshotsDir
+  }
 
   $DotCoverPath = Get-DotCoverExePath
 
-  $MergedSnapshotPath = "$OutputDir\coverage.dcvr"
+  $MergedSnapshotPath = "$CoverageOutputFolder\coverage.dcvr"
   # Use -ErrorAction SilentlyContinue to survive windows "path is too long" errors.
-  $snapshots = (Get-ChildItem $OutputDir -Filter *.coverage.snap -Recurse:$Recurse.IsPresent -ErrorAction SilentlyContinue).FullName
+  $snapshots = (Get-ChildItem $SnapshotsDir -Filter *.coverage.snap -Recurse:$Recurse.IsPresent -ErrorAction SilentlyContinue).FullName
   Write-Verbose "Merging snapshots: `r`n$snapshots`r`n`r`nto $MergedSnapshotPath"
 
   & $DotCoverPath merge /Source="$($snapshots -join ';')" /Output="$MergedSnapshotPath"
 
   if( $env:TEAMCITY_VERSION -eq $null ) {
     # Create an HTML report if running outside of Teamcity to help with debugging
-    & $DotCoverPath report /Source="$MergedSnapshotPath" /Output="$OutputDir\report.html" /reporttype=HTML
+    & $DotCoverPath report /Source="$MergedSnapshotPath" /Output="$CoverageOutputFolder\report.html" /reporttype=HTML
   } else {
     # Let Teamcity know where the current dotcover.exe we are using is
     TeamCity-ConfigureDotNetCoverage -key 'dotcover_home' -value ($DotCoverPath | Split-Path)

--- a/Public/Merge-CoverageReports.ps1
+++ b/Public/Merge-CoverageReports.ps1
@@ -28,6 +28,10 @@ function Merge-CoverageReports {
       $CoverageOutputFolder = $SnapshotsDir
   }
 
+  if(!(Test-Path $CoverageOutputFolder)) {
+      New-Item $CoverageOutputFolder -ItemType Directory -Force | Out-Null
+  }
+
   $DotCoverPath = Get-DotCoverExePath
 
   $MergedSnapshotPath = "$CoverageOutputFolder\coverage.dcvr"

--- a/Public/Merge-CoverageReports.ps1
+++ b/Public/Merge-CoverageReports.ps1
@@ -44,10 +44,10 @@ function Merge-CoverageReports {
   if( $env:TEAMCITY_VERSION -eq $null ) {
     # Create an HTML report if running outside of Teamcity to help with debugging
     & $DotCoverPath report /Source="$MergedSnapshotPath" /Output="$CoverageOutputFolder\report.html" /reporttype=HTML
-  } else {
-    # Let Teamcity know where the current dotcover.exe we are using is
-    TeamCity-ConfigureDotNetCoverage -key 'dotcover_home' -value ($DotCoverPath | Split-Path)
-    # Let Teamcity know where the report is.
-    TeamCity-ImportDotNetCoverageResult 'dotcover' $MergedSnapshotPath
   }
+
+  # Let Teamcity know where the current dotcover.exe we are using is
+  TeamCity-ConfigureDotNetCoverage -key 'dotcover_home' -value ($DotCoverPath | Split-Path)
+  # Let Teamcity know where the report is.
+  TeamCity-ImportDotNetCoverageResult 'dotcover' $MergedSnapshotPath
 }

--- a/Tests/Nunit/Build-NUnitCommandLineArguments.Tests.ps1
+++ b/Tests/Nunit/Build-NUnitCommandLineArguments.Tests.ps1
@@ -1,0 +1,66 @@
+#requires -Version 4 -Modules Pester
+
+$FullPathToModuleRoot = Resolve-Path $PSScriptRoot\..\..
+
+. "$FullPathToModuleRoot\Private\NUnit.ps1"
+
+Describe 'Build-NUnitCommandLineArguments' {
+
+    function Nunit2Parameters($assembly, $TestResult = 'TestResult') {
+        "$assembly /result=`"$assembly.$TestResult.xml`" /out=`"$assembly.$TestResult.TestOutput.txt`" /err=`"$assembly.$TestResult.TestError.txt`" /nologo /nodots /noshadow /labels"
+    }
+
+    function Nunit3Parameters($assembly, $TestResult = 'TestResult') {
+        "$assembly --result=`"$assembly.$TestResult.xml`" --out=`"$assembly.$TestResult.TestOutput.txt`" --err=`"$assembly.$TestResult.TestError.txt`" --noheader --labels=On"
+    }
+
+    Context 'Nunit 2.6.4 with minimum arguments' {
+        $result = Build-NUnitCommandLineArguments `
+            -AssemblyPath 'my-test-assembly.dll' `
+            -NUnitVersion '2.6.4'
+
+        It 'should return the right value' {
+            $result -join ' ' | Should Be (Nunit2Parameters 'my-test-assembly.dll')
+        }
+    }
+
+    Context 'Nunit 2.6.4 with all arguments' {
+        $result = Build-NUnitCommandLineArguments `
+            -AssemblyPath 'my-test-assembly.dll' `
+            -NUnitVersion '2.6.4' `
+            -x86 $true `
+            -FrameworkVersion 'net-4.0' `
+            -ExcludedCategories 'exclude1', 'exclude2' `
+            -IncludedCategories 'include1', 'include2' `
+            -TestResultFilenamePattern 'SpecialPattern'
+
+        It 'should return the right value' {
+            $result -join ' ' | Should Be "$(Nunit2Parameters 'my-test-assembly.dll' 'SpecialPattern') /framework=net-4.0 /exclude=exclude1;exclude2 /include=include1;include2"
+        }
+    }
+
+    Context 'Nunit 3.0.0 with minimum arguments' {
+        $result = Build-NUnitCommandLineArguments `
+            -AssemblyPath 'my-test-assembly.dll' `
+            -NUnitVersion '3.0.0'
+
+        It 'should return the right value' {
+            $result -join ' ' | Should Be (Nunit3Parameters 'my-test-assembly.dll')
+        }
+    }
+
+    Context 'Nunit 3.0.0 with all arguments' {
+        $result = Build-NUnitCommandLineArguments `
+            -AssemblyPath 'my-test-assembly.dll' `
+            -NUnitVersion '3.0.0' `
+            -x86 $true `
+            -FrameworkVersion 'net-4.0' `
+            -ExcludedCategories 'exclude1', 'exclude2' `
+            -IncludedCategories 'include1', 'include2' `
+            -TestResultFilenamePattern 'SpecialPattern'
+
+        It 'should return the right value' {
+            $result -join ' ' | Should Be "$(Nunit3Parameters 'my-test-assembly.dll' 'SpecialPattern') --x86 --framework=net-4.0 --exclude=exclude1;exclude2 --include=include1;include2"
+        }
+    }
+}

--- a/Tests/Nunit/Get-NUnitConsoleExePath.Tests.ps1
+++ b/Tests/Nunit/Get-NUnitConsoleExePath.Tests.ps1
@@ -1,0 +1,41 @@
+#requires -Version 4 -Modules Pester
+
+$FullPathToModuleRoot = Resolve-Path $PSScriptRoot\..\..
+
+. "$FullPathToModuleRoot\Private\NUnit.ps1"
+
+Describe 'Get-NUnitConsoleExePath' {
+
+    Context 'Nunit 2.6.4' {
+        $result = Get-NUnitConsoleExePath -NUnitVersion '2.6.4'
+
+        It 'should return the right path' {
+            $result | Should Be "$FullPathToModuleRoot\packages\NUnit.Runners.2.6.4\tools\nunit-console.exe"
+        }
+    }
+
+    Context 'Nunit 2.6.4 -x86' {
+        $result = Get-NUnitConsoleExePath -NUnitVersion '2.6.4' -x86
+
+        It 'should return the right path' {
+            $result | Should Be "$FullPathToModuleRoot\packages\NUnit.Runners.2.6.4\tools\nunit-console-x86.exe"
+        }
+    }
+
+    Context 'Nunit 3.0.0' {
+        $result = Get-NUnitConsoleExePath -NUnitVersion '3.0.0'
+
+        It 'should return the right path' {
+            $result | Should Be "$FullPathToModuleRoot\packages\NUnit.Console.3.0.0\tools\nunit3-console.exe"
+        }
+    }
+
+    Context 'Nunit 3.0.0 -x86' {
+        $result = Get-NUnitConsoleExePath -NUnitVersion '3.0.0' -x86
+
+        It 'should return the right path' {
+            # there is not nunit3-console-x86.exe
+            $result | Should Be "$FullPathToModuleRoot\packages\NUnit.Console.3.0.0\tools\nunit3-console.exe"
+        }
+    }
+}


### PR DESCRIPTION
See http://buildserver.red-gate.com/viewLog.html?buildId=7483806&tab=buildResultsDiv&buildTypeId=SQLClone_Build

Anyone else please feel free to pick this up. It's still failing with 

```
Invalid argument: /nologo
Invalid argument: /nodots
Invalid argument: /noshadow
The value '/out:C:\Repos\GitHub\sqlclone\RedGate.SqlClone.DataAccess.IntegrationTests\bin\Release\RedGate.SqlClone.DataAccess.IntegrationTests.dll.TestResult.TestOutput.txt' is not valid for option '--labels'.
```

I don't have time to fix it just now, but I was testing it out on SqlClone https://github.com/red-gate/SqlClone/compare/add-coverage?expand=1