### PR TITLE
Merge-CoverageReports improvements

### DIFF
--- a/Public/Merge-CoverageReports.ps1
+++ b/Public/Merge-CoverageReports.ps1
@@ -22,7 +22,8 @@ function Merge-CoverageReports {
   $DotCoverPath = Get-DotCoverExePath
 
   $MergedSnapshotPath = "$OutputDir\coverage.dcvr"
-  $snapshots = (Get-ChildItem $OutputDir -Filter *.coverage.snap -Recurse:$Recurse.IsPresent).FullName
+  # Use -ErrorAction SilentlyContinue to survive windows "path is too long" errors.
+  $snapshots = (Get-ChildItem $OutputDir -Filter *.coverage.snap -Recurse:$Recurse.IsPresent -ErrorAction SilentlyContinue).FullName
   Write-Verbose "Merging snapshots: `r`n$snapshots`r`n`r`nto $MergedSnapshotPath"
 
   & $DotCoverPath merge /Source="$($snapshots -join ';')" /Output="$MergedSnapshotPath"

--- a/Public/Merge-CoverageReports.ps1
+++ b/Public/Merge-CoverageReports.ps1
@@ -13,24 +13,33 @@ function Merge-CoverageReports {
   param(
     # The folder containing the coverage reports to be merged.
     [Parameter(Mandatory=$true)]
-    [string] $OutputDir,
+    [Alias('OutputDir')]
+    [string] $SnapshotsDir,
 
     # Also find coverage reports in child folders.
-    [switch] $Recurse
+    [switch] $Recurse,
+
+    # The folder where the merged coverage report will be saved.
+    # If not set, this will default to the value of -SnapshotsDir
+    [string] $CoverageOutputFolder
   )
+
+  if(!$CoverageOutputFolder) {
+      $CoverageOutputFolder = $SnapshotsDir
+  }
 
   $DotCoverPath = Get-DotCoverExePath
 
-  $MergedSnapshotPath = "$OutputDir\coverage.dcvr"
+  $MergedSnapshotPath = "$CoverageOutputFolder\coverage.dcvr"
   # Use -ErrorAction SilentlyContinue to survive windows "path is too long" errors.
-  $snapshots = (Get-ChildItem $OutputDir -Filter *.coverage.snap -Recurse:$Recurse.IsPresent -ErrorAction SilentlyContinue).FullName
+  $snapshots = (Get-ChildItem $SnapshotsDir -Filter *.coverage.snap -Recurse:$Recurse.IsPresent -ErrorAction SilentlyContinue).FullName
   Write-Verbose "Merging snapshots: `r`n$snapshots`r`n`r`nto $MergedSnapshotPath"
 
   & $DotCoverPath merge /Source="$($snapshots -join ';')" /Output="$MergedSnapshotPath"
 
   if( $env:TEAMCITY_VERSION -eq $null ) {
     # Create an HTML report if running outside of Teamcity to help with debugging
-    & $DotCoverPath report /Source="$MergedSnapshotPath" /Output="$OutputDir\report.html" /reporttype=HTML
+    & $DotCoverPath report /Source="$MergedSnapshotPath" /Output="$CoverageOutputFolder\report.html" /reporttype=HTML
   } else {
     # Let Teamcity know where the current dotcover.exe we are using is
     TeamCity-ConfigureDotNetCoverage -key 'dotcover_home' -value ($DotCoverPath | Split-Path)

--- a/Public/Merge-CoverageReports.ps1
+++ b/Public/Merge-CoverageReports.ps1
@@ -40,10 +40,10 @@ function Merge-CoverageReports {
   if( $env:TEAMCITY_VERSION -eq $null ) {
     # Create an HTML report if running outside of Teamcity to help with debugging
     & $DotCoverPath report /Source="$MergedSnapshotPath" /Output="$CoverageOutputFolder\report.html" /reporttype=HTML
-  } else {
-    # Let Teamcity know where the current dotcover.exe we are using is
-    TeamCity-ConfigureDotNetCoverage -key 'dotcover_home' -value ($DotCoverPath | Split-Path)
-    # Let Teamcity know where the report is.
-    TeamCity-ImportDotNetCoverageResult 'dotcover' $MergedSnapshotPath
   }
+
+  # Let Teamcity know where the current dotcover.exe we are using is
+  TeamCity-ConfigureDotNetCoverage -key 'dotcover_home' -value ($DotCoverPath | Split-Path)
+  # Let Teamcity know where the report is.
+  TeamCity-ImportDotNetCoverageResult 'dotcover' $MergedSnapshotPath
 }

--- a/Public/Merge-CoverageReports.ps1
+++ b/Public/Merge-CoverageReports.ps1
@@ -28,6 +28,10 @@ function Merge-CoverageReports {
       $CoverageOutputFolder = $SnapshotsDir
   }
 
+  if(!(Test-Path $CoverageOutputFolder)) {
+      New-Item $CoverageOutputFolder -ItemType Directory -Force | Out-Null
+  }
+
   $DotCoverPath = Get-DotCoverExePath
 
   $MergedSnapshotPath = "$CoverageOutputFolder\coverage.dcvr"

--- a/Public/Merge-CoverageReports.ps1
+++ b/Public/Merge-CoverageReports.ps1
@@ -21,20 +21,20 @@ function Merge-CoverageReports {
 
     # The folder where the merged coverage report will be saved.
     # If not set, this will default to the value of -SnapshotsDir
-    [string] $CoverageOutputFolder
+    [string] $CoverageOutputDir
   )
 
-  if(!$CoverageOutputFolder) {
-      $CoverageOutputFolder = $SnapshotsDir
+  if(!$CoverageOutputDir) {
+      $CoverageOutputDir = $SnapshotsDir
   }
 
-  if(!(Test-Path $CoverageOutputFolder)) {
-      New-Item $CoverageOutputFolder -ItemType Directory -Force | Out-Null
+  if(!(Test-Path $CoverageOutputDir)) {
+      New-Item $CoverageOutputDir -ItemType Directory -Force | Out-Null
   }
 
   $DotCoverPath = Get-DotCoverExePath
 
-  $MergedSnapshotPath = "$CoverageOutputFolder\coverage.dcvr"
+  $MergedSnapshotPath = "$CoverageOutputDir\coverage.dcvr"
   # Use -ErrorAction SilentlyContinue to survive windows "path is too long" errors.
   $snapshots = (Get-ChildItem $SnapshotsDir -Filter *.coverage.snap -Recurse:$Recurse.IsPresent -ErrorAction SilentlyContinue).FullName
   Write-Verbose "Merging snapshots: `r`n$snapshots`r`n`r`nto $MergedSnapshotPath"
@@ -43,7 +43,7 @@ function Merge-CoverageReports {
 
   if( $env:TEAMCITY_VERSION -eq $null ) {
     # Create an HTML report if running outside of Teamcity to help with debugging
-    & $DotCoverPath report /Source="$MergedSnapshotPath" /Output="$CoverageOutputFolder\report.html" /reporttype=HTML
+    & $DotCoverPath report /Source="$MergedSnapshotPath" /Output="$CoverageOutputDir\report.html" /reporttype=HTML
   }
 
   # Let Teamcity know where the current dotcover.exe we are using is


### PR DESCRIPTION
While playing with integrating Invoke-NUnitForAssembly with one of our product, I got a few issues and this is a PR to address them...

* Get-ChildItem can fail with `Path is too long` errors. Adding `-ErrorAction SilentlyContinue` swallows those errors. I think the risk of "missing" some snapshot files because of some other error we could now miss is quite low so it's probably all right?
* Renamed `-OutputDir` to `-SnapshotsDir` 
 * That's the folder where we're looking for coverage snapshot files.
 * Kept `-OutputDir` as an alias of `-SnapshotsDir` for backwards compatibility
* Added `-CoverageOutputDir` that can be set to generate the code coverage in a specific folder.
 * If not set, defaults to the value of `-SnapshotsDir`
* Print the Teamcity messages even when this is not being executed by a Teamcity build
 * Because it's always useful to see what messages are being sent to TC.