### PR TITLE
Enable code coverage

### DIFF
--- a/Public/Invoke-NUnit3ForAssembly.ps1
+++ b/Public/Invoke-NUnit3ForAssembly.ps1
@@ -52,7 +52,7 @@ function Invoke-NUnit3ForAssembly {
 
   $AssemblyPath = Resolve-Path $AssemblyPath
 
-  Write-Output "Executing tests from $AssemblyPath. (code coverage enabled: $EnableCodeCoverage.IsPresent)"
+  Write-Output "Executing tests from $AssemblyPath. (code coverage enabled: $EnableCodeCoverage)"
 
   try {
 
@@ -64,7 +64,7 @@ function Invoke-NUnit3ForAssembly {
 
     $NunitExecutable = Get-NUnit3ConsoleExePath -NUnitVersion $NUnitVersion
 
-    if( $EnableCodeCoverage.IsPresent ) {
+    if( $EnableCodeCoverage ) {
 
       Invoke-DotCoverForExecutable `
         -TargetExecutable $NunitExecutable `

--- a/Public/Invoke-NUnit3ForAssembly.ps1
+++ b/Public/Invoke-NUnit3ForAssembly.ps1
@@ -35,7 +35,7 @@ function Invoke-NUnit3ForAssembly {
     # the test result filename would be 'MyAssembly.Test.dll.TestResult.xml'
     [string] $TestResultFilenamePattern = 'TestResult',
     # If set, enable code coverage using dotcover
-    [bool] $EnableCodeCoverage = $false,
+    [switch] $EnableCodeCoverage,
     # The version of the nuget package containing DotCover.exe (JetBrains.dotCover.CommandLineTools)
     [string] $DotCoverVersion = $DefaultDotCoverVersion,
     # The dotcover filters passed to dotcover.exe
@@ -52,7 +52,7 @@ function Invoke-NUnit3ForAssembly {
 
   $AssemblyPath = Resolve-Path $AssemblyPath
 
-  Write-Output "Executing tests from $AssemblyPath. (code coverage enabled: $EnableCodeCoverage)"
+  Write-Output "Executing tests from $AssemblyPath. (code coverage enabled: $EnableCodeCoverage.IsPresent)"
 
   try {
 
@@ -64,7 +64,7 @@ function Invoke-NUnit3ForAssembly {
 
     $NunitExecutable = Get-NUnit3ConsoleExePath -NUnitVersion $NUnitVersion
 
-    if( $EnableCodeCoverage ) {
+    if( $EnableCodeCoverage.IsPresent ) {
 
       Invoke-DotCoverForExecutable `
         -TargetExecutable $NunitExecutable `

--- a/Public/Invoke-NUnitForAssembly.ps1
+++ b/Public/Invoke-NUnitForAssembly.ps1
@@ -37,7 +37,7 @@ function Invoke-NUnitForAssembly {
     # the test result filename would be 'MyAssembly.Test.dll.TestResult.xml'
     [string] $TestResultFilenamePattern = 'TestResult',
     # If set, enable code coverage using dotcover
-    [bool] $EnableCodeCoverage = $false,
+    [switch] $EnableCodeCoverage,
     # The version of the nuget package containing DotCover.exe (JetBrains.dotCover.CommandLineTools)
     [string] $DotCoverVersion = $DefaultDotCoverVersion,
     # The dotcover filters passed to dotcover.exe
@@ -61,7 +61,7 @@ function Invoke-NUnitForAssembly {
 
   $AssemblyPath = Resolve-Path $AssemblyPath
 
-  Write-Output "Executing tests from $AssemblyPath. (code coverage enabled: $EnableCodeCoverage)"
+  Write-Output "Executing tests from $AssemblyPath. (code coverage enabled: $EnableCodeCoverage.IsPresent)"
 
   try {
 
@@ -74,7 +74,7 @@ function Invoke-NUnitForAssembly {
 
     $NunitExecutable = Get-NUnitConsoleExePath -NUnitVersion $NUnitVersion -x86:$x86.IsPresent
 
-    if( $EnableCodeCoverage ) {
+    if( $EnableCodeCoverage.IsPresent ) {
 
       Invoke-DotCoverForExecutable `
         -TargetExecutable $NunitExecutable `

--- a/Public/Invoke-NUnitForAssembly.ps1
+++ b/Public/Invoke-NUnitForAssembly.ps1
@@ -61,7 +61,7 @@ function Invoke-NUnitForAssembly {
 
   $AssemblyPath = Resolve-Path $AssemblyPath
 
-  Write-Output "Executing tests from $AssemblyPath. (code coverage enabled: $EnableCodeCoverage.IsPresent)"
+  Write-Output "Executing tests from $AssemblyPath. (code coverage enabled: $EnableCodeCoverage)"
 
   try {
 
@@ -74,7 +74,7 @@ function Invoke-NUnitForAssembly {
 
     $NunitExecutable = Get-NUnitConsoleExePath -NUnitVersion $NUnitVersion -x86:$x86.IsPresent
 
-    if( $EnableCodeCoverage.IsPresent ) {
+    if( $EnableCodeCoverage ) {
 
       Invoke-DotCoverForExecutable `
         -TargetExecutable $NunitExecutable `


### PR DESCRIPTION
Doesn't seem to be a breaking change but conforms to docs now for `-EnableCodeCoverage` as switch not argument.

I tested `-EnableCodeCoverage $true` and it still worked.