### PR TITLE
Invoke nunit fixes

### DIFF
--- a/Private/NUnit/Publish-ResultsAndLogsToTeamcity.ps1
+++ b/Private/NUnit/Publish-ResultsAndLogsToTeamcity.ps1
@@ -3,9 +3,7 @@ function Publish-ResultsAndLogsToTeamcity {
     param(
         [Parameter(Mandatory=$true)]
         [String] $AssemblyPath,
-        [Parameter(Mandatory=$true)]
-        [String] $TestResultFilenamePattern,
-
+        [String] $TestResultFilenamePattern = 'TestResult',
         [bool] $ImportResultsToTeamcity
     )
 

--- a/Tests/Nunit/2/Invoke-NUnitForAssembly.Tests.ps1
+++ b/Tests/Nunit/2/Invoke-NUnitForAssembly.Tests.ps1
@@ -4,6 +4,8 @@ $FullPathToModuleRoot = Resolve-Path $PSScriptRoot\..\..\..
 
 Describe 'Invoke-NUnitForAssembly' {
 
+    $tempFolder = New-Item "$FullPathToModuleRoot\.temp\nunit" -ItemType Directory -Force -Verbose
+
     Context 'Nunit 4.0' {
         It "should throw Unexpected NUnit version" {
             { Invoke-NUnitForAssembly -Assembly 'myassembly.dll' -NUnitVersion '4.0' } | Should Throw "Unexpected NUnit version '4.0'. This function only supports Nunit v2"
@@ -14,5 +16,40 @@ Describe 'Invoke-NUnitForAssembly' {
         It "should throw Unexpected NUnit version" {
             { Invoke-NUnitForAssembly -Assembly 'myassembly.dll' -NUnitVersion '3.0' } | Should Throw "NUnit version '3.0' is not supported by this function. Use Invoke-NUnit3ForAssembly instead."
         }
+    }
+
+    function Compile-NUnitTests() {
+        Install-Package -Name NUnit.Runners -Version 2.6.4
+        $nunit = "$FullPathToModuleRoot\packages\NUnit.Runners.2.6.4"
+        @'
+using NUnit.Framework;
+
+namespace Tests
+{
+    [TestFixture]
+    public class SampleTests
+    {
+        [Test] public void AlwaysGreen() {}
+    }
+}
+'@  | Out-File $tempFolder\nunit-test.cs
+
+        Copy-Item $nunit\tools\nunit.framework.dll -Destination $tempFolder
+        $compiler = 'C:\Program Files (x86)\MSBuild\14.0\Bin\csc.exe'
+        $compiler | Should Exist
+        & $compiler /target:library /out:$tempFolder\nunit-test.dll $tempFolder\nunit-test.cs /reference:$tempFolder\nunit.framework.dll 2>&1 > $tempFolder\nunit-test.out.txt
+        $LASTEXITCODE | Should Be 0
+    }
+
+    Context 'Run real NUnit tests' {
+        Compile-NUnitTests
+
+        It 'Should not throw exceptions when TestResultFilenamePattern is empty' {
+            Invoke-NUnitForAssembly `
+                -AssemblyPath $tempFolder\nunit-test.dll `
+                -NUnitVersion '2.6.4' `
+                -TestResultFilenamePattern $null
+        }
+
     }
 }


### PR DESCRIPTION
@angellaa This is to fix the breaking change that is breaking your build.

(basically a new private function made `-TestResultFilenamePattern` a required parameter which it wasn't before)


I added a clunky test so that we get to run "Invoke-NUnitForAssembly" when we build `RedGate.Build`. It's ugly but hey this might catch things before we break your world again :blush: 