### PR TITLE
Advanced releasenotes

### DIFF
--- a/Public/Select-ReleaseNotes.ps1
+++ b/Public/Select-ReleaseNotes.ps1
@@ -6,11 +6,11 @@
   Version+Date = '^#+\s*(?<version>[0-9]+\.[0-9]+(\.[0-9]+)?(\.[0-9]+)?)(\s*-\s*(?<date>.*))?$'
   Date = '^#+\s*.*(?<date>\d\d\d\d.\d\d.\d\d)'
   Header = '^#+\s*(?<header>.+):?$'
-  
+
   eg
   # Stuff here before the first version
   Is ignored.
-  
+
   ## 1.2.3.4
   ##### Released on 2016-08-01
   This text goes into .Blocks.General
@@ -18,13 +18,13 @@
   FIX-01: This text goes into .Blocks.Fixes
   ### Internal:
   Don't show this to customers, it's in .Blocks.Internal
-  
+
   (Alternative date reading from SQL Compare markdown)
   # 1.2.3 - August 1st 2016
   # 1.2 - March 3rd, 2016
 .EXAMPLE
   Select-ReleaseNotes -ReleaseNotesPath SQLCompareUIs\COMPARE_RELEASENOTES.md
-  
+
   Version      Date                Blocks
   -------      ----                ------
   12.0.25.3064 13/09/2016 00:00:00 {General}
@@ -73,7 +73,7 @@ function Select-ReleaseNotes {
     } else {
         throw 'No $ReleaseNotesPath or $ReleaseNotes specified'
     }
-    
+
     # https://learn-powershell.net/2013/08/03/quick-hits-set-the-default-property-display-in-powershell-on-custom-objects/
     # Set up the default display set and create the member set object for use later on
     # Configure a default display set
@@ -85,8 +85,7 @@ function Select-ReleaseNotes {
 
     $VersionRegex = '^#+\s*(?<version>[0-9]+\.[0-9]+(\.[0-9]+)?(\.[0-9]+)?)(\s*-\s*(?<date>.*))?$'
     $HeaderRegex = '^#+\s*(?<header>.+):?$'
-    $DateRegex = '^#+\s*.*(?<date>\d\d\d\d.\d\d.\d\d)'    
-    
+    $DateRegex = '^#+\s*.*(?<date>\d\d\d\d.\d\d.\d\d)'
 
     $Release = $nul
     $IgnoreRest = $false
@@ -106,7 +105,7 @@ function Select-ReleaseNotes {
                     $Release.Blocks.$CurrentHeader = $Release.Blocks.$CurrentHeader.Trim()
                 }
                 $Release
-                
+
                 # If only getting one then ensure I skip everything else - can't use continue/break in a ForEach-Object
                 if ($Latest) {
                     $IgnoreRest = $true
@@ -114,7 +113,7 @@ function Select-ReleaseNotes {
                     return
                 }
             }
-            
+
             # Default Release object is created here with nice properties when in a list
             $CurrentHeader = 'General'
             $Release = [pscustomobject]@{

--- a/Public/Select-ReleaseNotes.ps1
+++ b/Public/Select-ReleaseNotes.ps1
@@ -34,7 +34,7 @@ function script:FinalizeRelease($release, [string]$currentHeader, [string]$produ
 }
 
 function script:AddFeature($accumulator, [int] $priority, [string] $feature) {
-    # If the same feature exists at a lower priority - raise the priority for the given priority
+    # If the same feature exists at a lower priority - raise the priority for the given feature
     if ($accumulator.Values -contains $feature) {
         $accumulator.Remove(($accumulator.GetEnumerator() |? {$_.Value -eq $feature}).Key)
     }
@@ -72,7 +72,7 @@ function script:GetSummary($productName, $release, $accumulator) {
   Date = '^#+\s*.*(?<date>\d\d\d\d.\d\d.\d\d)'
   Header = '^#+\s*(?<header>.+):?$'
   StraplineBlock = '^#+\s*Strapline\s*$'
-  Strapline = '^\s*(?<priority>[0-9]+)\.?\s*(?<feature>.*)\s*$'
+  Strapline = '^\s*(?<priority>[0-9]+)\s*-?\s*(?<feature>[^\.]*)\s*$'
 
   Example input
   -------------
@@ -97,9 +97,9 @@ function script:GetSummary($productName, $release, $accumulator) {
   ## 2.8.6.499
   ###### Released on 2016-07-12
   ### Strapline
-  65. Updated SQL Compare Engine
-  50. Login licensing
-  50. New feature usage reporting
+  65 - Updated SQL Compare Engine
+  50 - Login licensing
+  50 - New feature usage reporting
   
   ### Features
   * New login based licensing: see https://www.red-gate.com/user-licensing for more details
@@ -111,7 +111,7 @@ function script:GetSummary($productName, $release, $accumulator) {
   ## 2.8.5.530
   ###### Released on 2016-04-26
   ### Strapline
-  90. SSMS 2016
+  90 - SSMS 2016
   
   ### Features
   * Support for SSMS March 2016 Preview Refresh (VS2015 shell)
@@ -187,7 +187,7 @@ function Select-ReleaseNotes {
     $HeaderRegex = '^#+\s*(?<header>.+):?\s*$'
     $DateRegex = '^#+\s*.*(?<date>\d\d\d\d.\d\d.\d\d)'
     $StraplineStartRegex = '^#+\s*Strapline\s*$'
-    $StraplineRegex = '^\s*(?<priority>[0-9]+)\.?\s*(?<feature>.*)\s*$'
+    $StraplineRegex = '^\s*(?<priority>[0-9]+)\s*-?\s*(?<feature>[^\.]*)\s*$'
 
     $Accumulator = @{}
     $StraplineAccumulator = $false
@@ -254,7 +254,7 @@ function Select-ReleaseNotes {
                     if ($Line) {
                         $StraplineMatch = [regex]::Match($Line, $StraplineRegex)
                         if (!$StraplineMatch.Success) {
-                            throw "Strapline expected, encountered '$Line'"
+                            throw "Strapline expected (eg 123 - Title), encountered '$Line'"
                         }
                         AddFeature -accumulator $Accumulator `
                             -priority $StraplineMatch.Groups['priority'].Value `

--- a/Public/Select-ReleaseNotes.ps1
+++ b/Public/Select-ReleaseNotes.ps1
@@ -1,0 +1,128 @@
+<#
+.SYNOPSIS
+  Retrieves version information and release notes from a RELEASENOTES.md file
+.DESCRIPTION
+  Creates objects for each version block located in the file as defined by...
+  Version+Date = '^#+\s*(?<version>[0-9]+\.[0-9]+(\.[0-9]+)?(\.[0-9]+)?)(\s*-\s*(?<date>.*))?$'
+  Date = '^#+\s*.*(?<date>\d\d\d\d.\d\d.\d\d)'
+  Header = '^#+\s*(?<header>.+):?$'
+  
+  eg
+  # 1.2.3.4
+  ### Released on 2016-08-01
+  This text goes into .Blocks.General
+  ### Fixes
+  FIX-01: This text goes into .Blocks.Fixes
+  ### Internal:
+  Don't show this to customers, it's in .Blocks.Internal
+  
+  (Alternative date reading from SQL Compare markdown)
+  # 1.2.3 - August 1st 2016
+.EXAMPLE
+  Select-ReleaseNotes -ReleaseNotesPath SQLCompareUIs\COMPARE_RELEASENOTES.md
+  
+  Version      Date                Blocks
+  -------      ----                ------
+  12.0.25.3064 13/09/2016 00:00:00 {General}
+  12.0.24.3012 25/08/2016 00:00:00 {Fixes, General}
+  12.0.23.2976 25/08/2016 00:00:00 {Fixes, General}
+  12.0.22.2910 22/08/2016 00:00:00 {Fixes, General}
+  12.0.21.2819 16/08/2016 00:00:00 {Fixes}
+  12.0.20.2791 11/08/2016 00:00:00 {Fixes}
+  12.0.19.2758 09/08/2016 00:00:00 {Fixes}
+  12.0.18.2723 05/08/2016 00:00:00 {Fixes}
+  12.0.17.2708 04/08/2016 00:00:00 {Fixes}
+  12.0.16.2688 03/08/2016 00:00:00 {Fixes}
+  12.0.15.2659 02/08/2016 00:00:00 {Fixes}
+  12.0.14.2614 28/07/2016 00:00:00 {Features, Fixes}
+.EXAMPLE
+  Select-ReleaseNotes SQLSourceControl\RELEASENOTES.md
+
+  Version    Date                Blocks
+  -------    ----                ------
+  5.1.5                          {General}
+  5.1.4      08/07/2016 00:00:00 {Fixes, General}
+  5.1.3      06/07/2016 00:00:00 {Fixes, General}
+  5.1.2      29/06/2016 00:00:00 {Fixes, Features, General}
+  5.1.1      08/06/2016 00:00:00 {Fixes, General}
+  5.1.0      27/05/2016 00:00:00 {Fixes, General}
+  5.0.1      25/05/2016 00:00:00 {Fixes, General}
+  5.0.0      23/05/2016 00:00:00 {Major features, Fixes}
+  4.5.0      10/05/2016 00:00:00 {SQL Source Control 5 Beta, General}
+  4.4.2      03/05/2016 00:00:00 {Fixes, SQL Source Control 5 Beta, General}
+#>
+function Select-ReleaseNotes {
+    [CmdletBinding()]
+    param(
+        # The path of the RELEASENOTES.md file to read from
+        [Parameter(Mandatory=$true)]
+        [string] $ReleaseNotesPath
+    )
+    $Lines = Get-Content $ReleaseNotesPath
+    $VersionRegex = '^#+\s*(?<version>[0-9]+\.[0-9]+(\.[0-9]+)?(\.[0-9]+)?)(\s*-\s*(?<date>.*))?$'
+    $HeaderRegex = '^#+\s*(?<header>.+):?$'
+    $DateRegex = '^#+\s*.*(?<date>\d\d\d\d.\d\d.\d\d)'
+    
+    $Release = $nul
+    
+    # https://learn-powershell.net/2013/08/03/quick-hits-set-the-default-property-display-in-powershell-on-custom-objects/
+    # Set up the default display set and create the member set object for use later on
+    # Configure a default display set
+    $defaultDisplaySet = 'Version','Date','Blocks'
+
+    # Create the default property display set
+    $defaultDisplayPropertySet = New-Object System.Management.Automation.PSPropertySet('DefaultDisplayPropertySet',[string[]]$defaultDisplaySet)
+    $PSStandardMembers = [System.Management.Automation.PSMemberInfo[]]@($defaultDisplayPropertySet)
+
+    
+    $Lines | ForEach-Object {
+        $Line = $_.Trim()
+        $VersionMatch = [regex]::Match($Line, $VersionRegex)
+        if ($VersionMatch.Success) {
+            if ($Release) {
+                if ($Release.Blocks.$CurrentHeader) {
+                    $Release.Blocks.$CurrentHeader = $Release.Blocks.$CurrentHeader.Trim()
+                }
+                $Release
+            }
+            
+            $CurrentHeader = 'General'
+            $Release = [pscustomobject]@{
+                Version = [version] $VersionMatch.Groups['version'].Value
+                Date = $nul
+                Blocks = @{}
+            }
+            $Release.PSObject.TypeNames.Insert(0,'RedGate.Build.VersionInformation')
+            $Release | Add-Member MemberSet PSStandardMembers $PSStandardMembers
+
+            if ($VersionMatch.Groups['date'].Success) {
+                $simpleDate = $VersionMatch.Groups['date'].Value
+                $simpleDate = $simpleDate -replace '(\d+)(st|nd|rd|th)', '$1' -replace ','
+                $Release.Date = [DateTime] $simpleDate
+            }
+        } elseif ($Release) {
+            $DateMatch = [regex]::Match($Line, $DateRegex)
+            $HeaderMatch = [regex]::Match($Line, $HeaderRegex)
+            if ($DateMatch.Success) {
+                $Release.Date = [DateTime] $DateMatch.Groups['date'].Value
+            } elseif ($HeaderMatch.Success) {
+                if ($Release.Blocks.$CurrentHeader) {
+                    $Release.Blocks.$CurrentHeader = $Release.Blocks.$CurrentHeader.Trim()
+                }
+                $CurrentHeader = $HeaderMatch.Groups['header'].Value
+            } else {
+                if ($Release.Blocks.$CurrentHeader) {
+                    $Release.Blocks.$CurrentHeader += [System.Environment]::NewLine + $Line
+                } else {
+                    $Release.Blocks.$CurrentHeader = $Line
+                }
+            }
+        }
+    }
+    if ($Release) {
+        if ($Release.Blocks.$CurrentHeader) {
+            $Release.Blocks.$CurrentHeader = $Release.Blocks.$CurrentHeader.Trim()
+        }
+        $Release
+    }
+}

--- a/Public/Select-ReleaseNotes.ps1
+++ b/Public/Select-ReleaseNotes.ps1
@@ -192,15 +192,9 @@ function Select-ReleaseNotes {
     $Accumulator = @{}
     $StraplineAccumulator = $false
     $Release = $nul
-    $IgnoreRest = $false
     
-    $Lines | ForEach-Object {
-        if ($IgnoreRest)
-        {
-            # I seem to have to keep processing
-            return
-        }
-        $Line = $_.Trim()
+    foreach($Line in $Lines) {
+        $Line = $Line.Trim()
         $VersionMatch = [regex]::Match($Line, $VersionRegex)
         if ($VersionMatch.Success) {
             # If a $Release already was being filled in - clean it up and return it
@@ -210,11 +204,10 @@ function Select-ReleaseNotes {
                 # Return out of the pipeline
                 $Release
                 
-                # If only getting one then ensure I skip everything else - can't use continue/break in a ForEach-Object
+                # If only getting one then ensure I skip everything else
                 if ($Latest) {
-                    $IgnoreRest = $true
                     $Release = $nul
-                    return
+                    break
                 }
             }
             
@@ -249,6 +242,7 @@ function Select-ReleaseNotes {
                 $StraplineAccumulator = $false
                 $CurrentHeader = $HeaderMatch.Groups['header'].Value
             } else {
+                # This is a line in a block, either a Strapline or a "normal" line
                 if ($StraplineAccumulator) {
                     # Ignore newlines in Strapline section
                     if ($Line) {
@@ -271,6 +265,7 @@ function Select-ReleaseNotes {
             }
         }
     }
+
     # Clean up and return the last $Release object being populated (if there is one)
     if ($Release) {
         FinalizeRelease -Release $Release -ProductName $ProductName -CurrentHeader $CurrentHeader -Accumulator $Accumulator

--- a/Public/Select-ReleaseNotes.ps1
+++ b/Public/Select-ReleaseNotes.ps1
@@ -8,8 +8,11 @@
   Header = '^#+\s*(?<header>.+):?$'
   
   eg
-  # 1.2.3.4
-  ### Released on 2016-08-01
+  # Stuff here before the first version
+  Is ignored.
+  
+  ## 1.2.3.4
+  ##### Released on 2016-08-01
   This text goes into .Blocks.General
   ### Fixes
   FIX-01: This text goes into .Blocks.Fixes
@@ -18,6 +21,7 @@
   
   (Alternative date reading from SQL Compare markdown)
   # 1.2.3 - August 1st 2016
+  # 1.2 - March 3rd, 2016
 .EXAMPLE
   Select-ReleaseNotes -ReleaseNotesPath SQLCompareUIs\COMPARE_RELEASENOTES.md
   
@@ -55,10 +59,19 @@ function Select-ReleaseNotes {
     [CmdletBinding()]
     param(
         # The path of the RELEASENOTES.md file to read from
-        [Parameter(Mandatory=$true)]
-        [string] $ReleaseNotesPath
+        [string] $ReleaseNotesPath,
+        # The RELEASENOTES markdown to select from
+        [string] $ReleaseNotes
     )
-    $Lines = Get-Content $ReleaseNotesPath
+    if ($ReleaseNotesPath) {
+        $Lines = Get-Content $ReleaseNotesPath
+    } elseif ($ReleaseNotes) {
+        # Makes testing easier
+        $Lines = ($ReleaseNotes -Replace "'r").Split("`n")
+    } else {
+        throw 'No $ReleaseNotesPath or $ReleaseNotes specified'
+    }
+    
     $VersionRegex = '^#+\s*(?<version>[0-9]+\.[0-9]+(\.[0-9]+)?(\.[0-9]+)?)(\s*-\s*(?<date>.*))?$'
     $HeaderRegex = '^#+\s*(?<header>.+):?$'
     $DateRegex = '^#+\s*.*(?<date>\d\d\d\d.\d\d.\d\d)'
@@ -74,7 +87,6 @@ function Select-ReleaseNotes {
     $defaultDisplayPropertySet = New-Object System.Management.Automation.PSPropertySet('DefaultDisplayPropertySet',[string[]]$defaultDisplaySet)
     $PSStandardMembers = [System.Management.Automation.PSMemberInfo[]]@($defaultDisplayPropertySet)
 
-    
     $Lines | ForEach-Object {
         $Line = $_.Trim()
         $VersionMatch = [regex]::Match($Line, $VersionRegex)

--- a/Public/Select-ReleaseNotes.ps1
+++ b/Public/Select-ReleaseNotes.ps1
@@ -1,4 +1,4 @@
-function script:CreateRelease([version] $version)
+function CreateRelease([version] $version)
 {
     # https://learn-powershell.net/2013/08/03/quick-hits-set-the-default-property-display-in-powershell-on-custom-objects/
     # Set up the default display set and create the member set object for use later on
@@ -22,7 +22,7 @@ function script:CreateRelease([version] $version)
     return $release
 }
 
-function script:FinalizeRelease($release, [string]$currentHeader, [string]$productName, $accumulator) {
+function FinalizeRelease($release, [string]$currentHeader, [string]$productName, $accumulator) {
     if ($release.Blocks.$currentHeader) {
         $release.Blocks.$currentHeader = $release.Blocks.$currentHeader.Trim()
     }
@@ -33,7 +33,7 @@ function script:FinalizeRelease($release, [string]$currentHeader, [string]$produ
     $release.Summary = GetSummary -ProductName $productName -Release $release -Accumulator $accumulator
 }
 
-function script:AddFeature($accumulator, [int] $priority, [string] $feature) {
+function AddFeature($accumulator, [int] $priority, [string] $feature) {
     # If the same feature exists at a lower priority - raise the priority for the given feature
     if ($accumulator.Values -contains $feature) {
         $accumulator.Remove(($accumulator.GetEnumerator() |? {$_.Value -eq $feature}).Key)
@@ -48,7 +48,7 @@ function script:AddFeature($accumulator, [int] $priority, [string] $feature) {
     $accumulator.($key) = $feature
 }
 
-function script:GetSummary($productName, $release, $accumulator) {    
+function GetSummary($productName, $release, $accumulator) {    
     $summary = $accumulator.GetEnumerator() | sort {$_.Key} -Descending
     if ($summary) {
         return [string]::Join(", ", $summary.Value)

--- a/Public/Select-ReleaseNotes.ps1
+++ b/Public/Select-ReleaseNotes.ps1
@@ -163,11 +163,13 @@ function script:GetSummary($productName, $release, $accumulator) {
   5.1.5        {General} SQL Source Control 5.1.5
 #>
 function Select-ReleaseNotes {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName='Path')]
     param(
         # The path of the RELEASENOTES.md file to read from
+        [Parameter(Mandatory = $true, ParameterSetName = 'Path', Position = 0)]
         [string] $ReleaseNotesPath,
         # The RELEASENOTES markdown to select from
+        [Parameter(Mandatory = $true, ParameterSetName = 'String', Position = 0)]
         [string] $ReleaseNotes,
         # Only return the top version block in the file
         [switch] $Latest,
@@ -180,6 +182,7 @@ function Select-ReleaseNotes {
         # Makes testing easier
         $Lines = ($ReleaseNotes -Replace "'r").Split("`n")
     } else {
+        # Shouldn't happen due to ParameterSetName usage above
         throw 'No $ReleaseNotesPath or $ReleaseNotes specified'
     }
 

--- a/Public/Select-ReleaseNotes.ps1
+++ b/Public/Select-ReleaseNotes.ps1
@@ -61,7 +61,9 @@ function Select-ReleaseNotes {
         # The path of the RELEASENOTES.md file to read from
         [string] $ReleaseNotesPath,
         # The RELEASENOTES markdown to select from
-        [string] $ReleaseNotes
+        [string] $ReleaseNotes,
+        # Only return the top version block in the file
+        [switch] $Latest
     )
     if ($ReleaseNotesPath) {
         $Lines = Get-Content $ReleaseNotesPath
@@ -87,7 +89,12 @@ function Select-ReleaseNotes {
     $defaultDisplayPropertySet = New-Object System.Management.Automation.PSPropertySet('DefaultDisplayPropertySet',[string[]]$defaultDisplaySet)
     $PSStandardMembers = [System.Management.Automation.PSMemberInfo[]]@($defaultDisplayPropertySet)
 
+    $IgnoreRest = $false
     $Lines | ForEach-Object {
+        if ($IgnoreRest)
+        {
+            return
+        }
         $Line = $_.Trim()
         $VersionMatch = [regex]::Match($Line, $VersionRegex)
         if ($VersionMatch.Success) {
@@ -96,6 +103,11 @@ function Select-ReleaseNotes {
                     $Release.Blocks.$CurrentHeader = $Release.Blocks.$CurrentHeader.Trim()
                 }
                 $Release
+                if ($Latest) {
+                    $IgnoreRest = $true
+                    $Release = $nul
+                    return
+                }
             }
             
             $CurrentHeader = 'General'

--- a/Tests/Read-ReleaseNotes.Tests.ps1
+++ b/Tests/Read-ReleaseNotes.Tests.ps1
@@ -51,14 +51,12 @@ Describe 'Read-ReleaseNotes' {
             $info.Version | Should Be "19.99"
         }
 
-        Context 'Ignore Wrong Version' {
+        Context 'Fail If Not First Version' {
             Mock Get-Content {
                 "# 1.2.3"
                 "# 19.99"
             }
-            $info = Read-ReleaseNotes -ReleaseNotesPath "DoesNotExist\RELEASENOTES.md"
-            $info.Content | Should Be "# 19.99"
-            $info.Version | Should Be "19.99"
+            { Read-ReleaseNotes -ReleaseNotesPath "DoesNotExist\RELEASENOTES.md" } | Should Throw
         }
     }
 }

--- a/Tests/Select-ReleaseNotes.Tests.ps1
+++ b/Tests/Select-ReleaseNotes.Tests.ps1
@@ -121,4 +121,33 @@ Cool feature
             $vs[2].Blocks.Fixes | Should Be $nul
         }
     }
+    
+    InModuleScope RedGate.Build {
+        Context 'Latest Multiple Versions' {
+            $v = Select-ReleaseNotes -Latest -ReleaseNotes @"
+# SQL Dependency Tracker Release Notes
+## 2.8.9
+### Features
+* Updated to the latest SQL Compare engine, version 12, featuring a number of fixes and enhancements.  Removes support for SQL Server 2000 databases.
+
+### Fixes
+* Latest UI components, fixes initial window position, layout issues and a rare crash
+
+## 2.8.8.523
+###### Released on 2016-08-11
+### Fixes
+* Updated feature usage reporting library
+* Latest UI components, uses a more legible font on the menu
+* Old activations of SQL Dependency Tracker now work as expected
+
+## 2.8.7.512
+###### Failed release on 2016-08-01
+"@
+            $v.Version | Should Be '2.8.9'
+            $v.Date | Should Be $nul
+            $v.Blocks.General | Should Be $nul
+            $v.Blocks.Features | Should Be '* Updated to the latest SQL Compare engine, version 12, featuring a number of fixes and enhancements.  Removes support for SQL Server 2000 databases.'
+            $v.Blocks.Fixes | Should Be '* Latest UI components, fixes initial window position, layout issues and a rare crash'
+        }
+    }
 }

--- a/Tests/Select-ReleaseNotes.Tests.ps1
+++ b/Tests/Select-ReleaseNotes.Tests.ps1
@@ -4,8 +4,9 @@ Describe 'Read-ReleaseNotes' {
     InModuleScope RedGate.Build {
         Context 'Two Part Version' {
             Mock Get-Content { '# 1.2' }
-            $v = Select-ReleaseNotes -ReleaseNotesPath 'DoesNotExist\RELEASENOTES.md'
+            $v = Select-ReleaseNotes -ProductName "Test" -ReleaseNotesPath 'DoesNotExist\RELEASENOTES.md'
             $v.Version | Should Be '1.2'
+            $v.Summary | Should Be 'Test 1.2'
             $v.Date | Should Be $nul
             $v.Blocks.General | Should Be $nul
         }
@@ -14,8 +15,9 @@ Describe 'Read-ReleaseNotes' {
     InModuleScope RedGate.Build {
         Context 'Three Part Version' {
             Mock Get-Content { '##1.2.3' }
-            $v = Select-ReleaseNotes -ReleaseNotesPath 'DoesNotExist\RELEASENOTES.md'
+            $v = Select-ReleaseNotes -ProductName "Test" -ReleaseNotesPath 'DoesNotExist\RELEASENOTES.md'
             $v.Version | Should Be '1.2.3'
+            $v.Summary | Should Be 'Test 1.2.3'
             $v.Date | Should Be $nul
             $v.Blocks.General | Should Be $nul
         }
@@ -24,8 +26,9 @@ Describe 'Read-ReleaseNotes' {
     InModuleScope RedGate.Build {
         Context 'Four Part Version' {
             Mock Get-Content { '### 1.2.3.4   ' }
-            $v = Select-ReleaseNotes -ReleaseNotesPath 'DoesNotExist\RELEASENOTES.md'
+            $v = Select-ReleaseNotes -ProductName "Test" -ReleaseNotesPath 'DoesNotExist\RELEASENOTES.md'
             $v.Version | Should Be '1.2.3.4'
+            $v.Summary | Should Be 'Test 1.2.3'
             $v.Date | Should Be $nul
             $v.Blocks.General | Should Be $nul
         }
@@ -37,6 +40,8 @@ Describe 'Read-ReleaseNotes' {
 # SQL Dependency Tracker Release Notes
 ## 2.8.9
 General content
+### Strapline
+100. Feature
 
 ### Features
 Cool feature
@@ -45,6 +50,7 @@ Cool feature
 * Nasty fix
 "@
             $v.Version | Should Be '2.8.9'
+            $v.Summary | Should Be 'Feature'
             $v.Date | Should Be $nul
             $v.Blocks.General | Should Be 'General content'
             $v.Blocks.Features | Should Be 'Cool Feature'
@@ -54,11 +60,12 @@ Cool feature
     
     InModuleScope RedGate.Build {
         Context 'SOC Date' {
-            $v = Select-ReleaseNotes -ReleaseNotes @"
+            $v = Select-ReleaseNotes -ProductName "SQL Source Control" -ReleaseNotes @"
 ## 5.1.4
 ###### Released on 2016-07-08
 "@
             $v.Version | Should Be '5.1.4'
+            $v.Summary | Should Be 'SQL Source Control 5.1.4'
             $v.Date | Should Be ([DateTime] '2016-07-08')
             $v.Blocks.General | Should Be $nul
         }
@@ -66,10 +73,11 @@ Cool feature
     
     InModuleScope RedGate.Build {
         Context 'SQL Compare Date' {
-            $v = Select-ReleaseNotes -ReleaseNotes @"
+            $v = Select-ReleaseNotes -ProductName "SQL Compare" -ReleaseNotes @"
 ## 12.0.25.3064 - September 13th 2016
 "@
             $v.Version | Should Be '12.0.25.3064'
+            $v.Summary | Should Be 'SQL Compare 12.0.25'
             $v.Date | Should Be ([DateTime] '2016-09-13')
             $v.Blocks.General | Should Be $nul
         }
@@ -80,6 +88,9 @@ Cool feature
             $vs = Select-ReleaseNotes -ReleaseNotes @"
 # SQL Dependency Tracker Release Notes
 ## 2.8.9
+### Strapline
+65. Updated SQL Compare Engine
+
 ### Features
 * Updated to the latest SQL Compare engine, version 12, featuring a number of fixes and enhancements.  Removes support for SQL Server 2000 databases.
 
@@ -88,6 +99,9 @@ Cool feature
 
 ## 2.8.8.523
 ###### Released on 2016-08-11
+### Strapline
+10. Bug fixes
+
 ### Fixes
 * Updated feature usage reporting library
 * Latest UI components, uses a more legible font on the menu
@@ -98,12 +112,14 @@ Cool feature
 "@
             $vs.Length | Should Be 3
             $vs[0].Version | Should Be '2.8.9'
+            $vs[0].Summary | Should Be 'Updated SQL Compare Engine'
             $vs[0].Date | Should Be $nul
             $vs[0].Blocks.General | Should Be $nul
             $vs[0].Blocks.Features | Should Be '* Updated to the latest SQL Compare engine, version 12, featuring a number of fixes and enhancements.  Removes support for SQL Server 2000 databases.'
             $vs[0].Blocks.Fixes | Should Be '* Latest UI components, fixes initial window position, layout issues and a rare crash'
             
             $vs[1].Version | Should Be '2.8.8.523'
+            $vs[1].Summary | Should Be 'Updated SQL Compare Engine, Bug Fixes'
             $vs[1].Date | Should Be ([DateTime] '2016-08-11')
             $vs[1].Blocks.General | Should Be $nul
             $vs[1].Blocks.Features | Should Be $nul
@@ -114,8 +130,8 @@ Cool feature
 "@
             
             $vs[2].Version | Should Be '2.8.7.512'
+            $vs[2].Summary | Should Be 'Updated SQL Compare Engine, Bug Fixes'
             $vs[2].Date | Should Be ([DateTime] '2016-08-01')
-                        $vs[0].Blocks.General | Should Be $nul
             $vs[2].Blocks.General | Should Be $nul
             $vs[2].Blocks.Features | Should Be $nul
             $vs[2].Blocks.Fixes | Should Be $nul
@@ -124,7 +140,7 @@ Cool feature
     
     InModuleScope RedGate.Build {
         Context 'Latest Multiple Versions' {
-            $v = Select-ReleaseNotes -Latest -ReleaseNotes @"
+            $v = Select-ReleaseNotes -ProductName "Test" -Latest -ReleaseNotes @"
 # SQL Dependency Tracker Release Notes
 ## 2.8.9
 ### Features
@@ -144,6 +160,7 @@ Cool feature
 ###### Failed release on 2016-08-01
 "@
             $v.Version | Should Be '2.8.9'
+            $v.Summary | Should Be 'Test 2.8.9'
             $v.Date | Should Be $nul
             $v.Blocks.General | Should Be $nul
             $v.Blocks.Features | Should Be '* Updated to the latest SQL Compare engine, version 12, featuring a number of fixes and enhancements.  Removes support for SQL Server 2000 databases.'

--- a/Tests/Select-ReleaseNotes.Tests.ps1
+++ b/Tests/Select-ReleaseNotes.Tests.ps1
@@ -1,0 +1,124 @@
+#requires -Version 4 -Modules Pester
+
+Describe 'Read-ReleaseNotes' {
+    InModuleScope RedGate.Build {
+        Context 'Two Part Version' {
+            Mock Get-Content { '# 1.2' }
+            $v = Select-ReleaseNotes -ReleaseNotesPath 'DoesNotExist\RELEASENOTES.md'
+            $v.Version | Should Be '1.2'
+            $v.Date | Should Be $nul
+            $v.Blocks.General | Should Be $nul
+        }
+    }
+
+    InModuleScope RedGate.Build {
+        Context 'Three Part Version' {
+            Mock Get-Content { '##1.2.3' }
+            $v = Select-ReleaseNotes -ReleaseNotesPath 'DoesNotExist\RELEASENOTES.md'
+            $v.Version | Should Be '1.2.3'
+            $v.Date | Should Be $nul
+            $v.Blocks.General | Should Be $nul
+        }
+    }
+
+    InModuleScope RedGate.Build {
+        Context 'Four Part Version' {
+            Mock Get-Content { '### 1.2.3.4' }
+            $v = Select-ReleaseNotes -ReleaseNotesPath 'DoesNotExist\RELEASENOTES.md'
+            $v.Version | Should Be '1.2.3.4'
+            $v.Date | Should Be $nul
+            $v.Blocks.General | Should Be $nul
+        }
+    }
+    
+    InModuleScope RedGate.Build {
+        Context 'SDT Top' {
+            $v = Select-ReleaseNotes -ReleaseNotes @"
+# SQL Dependency Tracker Release Notes
+## 2.8.9
+General content
+
+### Features
+Cool feature
+
+### Fixes
+* Nasty fix
+"@
+            $v.Version | Should Be '2.8.9'
+            $v.Date | Should Be $nul
+            $v.Blocks.General | Should Be 'General content'
+            $v.Blocks.Features | Should Be 'Cool Feature'
+            $v.Blocks.Fixes | Should Be '* Nasty fix'
+        }
+    }
+    
+    InModuleScope RedGate.Build {
+        Context 'SOC Date' {
+            $v = Select-ReleaseNotes -ReleaseNotes @"
+## 5.1.4
+###### Released on 2016-07-08
+"@
+            $v.Version | Should Be '5.1.4'
+            $v.Date | Should Be ([DateTime] '2016-07-08')
+            $v.Blocks.General | Should Be $nul
+        }
+    }
+    
+    InModuleScope RedGate.Build {
+        Context 'SQL Compare Date' {
+            $v = Select-ReleaseNotes -ReleaseNotes @"
+## 12.0.25.3064 - September 13th 2016
+"@
+            $v.Version | Should Be '12.0.25.3064'
+            $v.Date | Should Be ([DateTime] '2016-09-13')
+            $v.Blocks.General | Should Be $nul
+        }
+    }
+        
+    InModuleScope RedGate.Build {
+        Context 'Multiple Versions' {
+            $vs = Select-ReleaseNotes -ReleaseNotes @"
+# SQL Dependency Tracker Release Notes
+## 2.8.9
+### Features
+* Updated to the latest SQL Compare engine, version 12, featuring a number of fixes and enhancements.  Removes support for SQL Server 2000 databases.
+
+### Fixes
+* Latest UI components, fixes initial window position, layout issues and a rare crash
+
+## 2.8.8.523
+###### Released on 2016-08-11
+### Fixes
+* Updated feature usage reporting library
+* Latest UI components, uses a more legible font on the menu
+* Old activations of SQL Dependency Tracker now work as expected
+
+## 2.8.7.512
+###### Failed release on 2016-08-01
+"@
+            $vs.Length | Should Be 3
+            $vs[0].Version | Should Be '2.8.9'
+            $vs[0].Date | Should Be $nul
+            $vs[0].Blocks.General | Should Be $nul
+            $vs[0].Blocks.Features | Should Be '* Updated to the latest SQL Compare engine, version 12, featuring a number of fixes and enhancements.  Removes support for SQL Server 2000 databases.'
+            $vs[0].Blocks.Fixes | Should Be '* Latest UI components, fixes initial window position, layout issues and a rare crash'
+            
+            $vs[1].Version | Should Be '2.8.8.523'
+            $vs[1].Date | Should Be ([DateTime] '2016-08-11')
+            $vs[1].Blocks.General | Should Be $nul
+            $vs[1].Blocks.Features | Should Be $nul
+            $vs[1].Blocks.Fixes | Should Be @"
+* Updated feature usage reporting library
+* Latest UI components, uses a more legible font on the menu
+* Old activations of SQL Dependency Tracker now work as expected
+"@
+            
+            $vs[2].Version | Should Be '2.8.7.512'
+            $vs[2].Date | Should Be ([DateTime] '2016-08-01')
+                        $vs[0].Blocks.General | Should Be $nul
+            $vs[2].Blocks.General | Should Be $nul
+            $vs[2].Blocks.Features | Should Be $nul
+            $vs[2].Blocks.Fixes | Should Be $nul
+        }
+    }
+}

--- a/Tests/Select-ReleaseNotes.Tests.ps1
+++ b/Tests/Select-ReleaseNotes.Tests.ps1
@@ -41,7 +41,7 @@ Describe 'Read-ReleaseNotes' {
 ## 2.8.9
 General content
 ### Strapline
-100. Feature
+100 - Feature
 
 ### Features
 Cool feature
@@ -89,7 +89,7 @@ Cool feature
 # SQL Dependency Tracker Release Notes
 ## 2.8.9
 ### Strapline
-65. Updated SQL Compare Engine
+65 - Updated SQL Compare Engine
 
 ### Features
 * Updated to the latest SQL Compare engine, version 12, featuring a number of fixes and enhancements.  Removes support for SQL Server 2000 databases.
@@ -100,7 +100,7 @@ Cool feature
 ## 2.8.8.523
 ###### Released on 2016-08-11
 ### Strapline
-10. Bug fixes
+10 - Bug fixes
 
 ### Fixes
 * Updated feature usage reporting library
@@ -173,12 +173,12 @@ Cool feature
             $vs = Select-ReleaseNotes -ProductName "Test" -ReleaseNotes @"
 ## 1.2.3.4
 ### Strapline
-50.Top
-10.Bottom
+50-Top
+10-Bottom
 
 ## 1.0.0.0
 ### Strapline
-10.Also Bottom
+10 Also Bottom
 "@
             $vs.Length | Should Be 2
             $vs[0].Version | Should Be '1.2.3.4'
@@ -194,12 +194,12 @@ Cool feature
             $vs = Select-ReleaseNotes -ProductName "Test" -ReleaseNotes @"
 ## 1.2.3.4
 ### Strapline
-50.Top
-10.Thing
+50 - Top
+10 -Thing
 
 ## 1.0.0.0
 ### Strapline
-99.Thing
+99- Thing
 "@
             $vs.Length | Should Be 2
             $vs[0].Version | Should Be '1.2.3.4'
@@ -215,13 +215,13 @@ Cool feature
             $vs = Select-ReleaseNotes -ProductName "Test" -ReleaseNotes @"
 ## 1.2.3.4
 ### Strapline
-50.Top
-10.Other thing
-10.Thing
+50 - Top
+10 - Other thing
+10 - Thing
 
 ## 1.0.0.0
 ### Strapline
-99.Thing
+99 - Thing
 "@
             $vs.Length | Should Be 2
             $vs[0].Version | Should Be '1.2.3.4'
@@ -229,6 +229,26 @@ Cool feature
 
             $vs[1].Version | Should Be '1.0.0.0'
             $vs[1].Summary | Should Be 'Thing, Top, Other thing'
+        }
+    }
+
+    InModuleScope RedGate.Build {
+        Context 'Invalid Strapline' {
+            { Select-ReleaseNotes -ProductName "Test" -ReleaseNotes @"
+## 1.2.3.4
+### Strapline
+50. This would look like 1. xxx on github (bad)
+"@} | Should Throw
+        }
+    }
+    
+    InModuleScope RedGate.Build {
+        Context 'Not Strapline' {
+            { Select-ReleaseNotes -ProductName "Test" -ReleaseNotes @"
+## 1.2.3.4
+### Strapline
+Just trying to put any text here isn't allowed
+"@} | Should Throw
         }
     }
 }

--- a/Tests/Select-ReleaseNotes.Tests.ps1
+++ b/Tests/Select-ReleaseNotes.Tests.ps1
@@ -1,6 +1,6 @@
 #requires -Version 4 -Modules Pester
 
-Describe 'Read-ReleaseNotes' {
+Describe 'Select-ReleaseNotes' {
     InModuleScope RedGate.Build {
         Context 'Two Part Version' {
             Mock Get-Content { '# 1.2' }

--- a/Tests/Select-ReleaseNotes.Tests.ps1
+++ b/Tests/Select-ReleaseNotes.Tests.ps1
@@ -33,7 +33,7 @@ Describe 'Read-ReleaseNotes' {
             $v.Blocks.General | Should Be $nul
         }
     }
-    
+
     InModuleScope RedGate.Build {
         Context 'SDT Top' {
             $v = Select-ReleaseNotes -ReleaseNotes @"
@@ -57,7 +57,7 @@ Cool feature
             $v.Blocks.Fixes | Should Be '* Nasty fix'
         }
     }
-    
+
     InModuleScope RedGate.Build {
         Context 'SOC Date' {
             $v = Select-ReleaseNotes -ProductName "SQL Source Control" -ReleaseNotes @"
@@ -70,7 +70,7 @@ Cool feature
             $v.Blocks.General | Should Be $nul
         }
     }
-    
+
     InModuleScope RedGate.Build {
         Context 'SQL Compare Date' {
             $v = Select-ReleaseNotes -ProductName "SQL Compare" -ReleaseNotes @"
@@ -82,7 +82,7 @@ Cool feature
             $v.Blocks.General | Should Be $nul
         }
     }
-        
+
     InModuleScope RedGate.Build {
         Context 'Multiple Versions' {
             $vs = Select-ReleaseNotes -ReleaseNotes @"
@@ -117,7 +117,7 @@ Cool feature
             $vs[0].Blocks.General | Should Be $nul
             $vs[0].Blocks.Features | Should Be '* Updated to the latest SQL Compare engine, version 12, featuring a number of fixes and enhancements.  Removes support for SQL Server 2000 databases.'
             $vs[0].Blocks.Fixes | Should Be '* Latest UI components, fixes initial window position, layout issues and a rare crash'
-            
+
             $vs[1].Version | Should Be '2.8.8.523'
             $vs[1].Summary | Should Be 'Updated SQL Compare Engine, Bug Fixes'
             $vs[1].Date | Should Be ([DateTime] '2016-08-11')
@@ -128,7 +128,7 @@ Cool feature
 * Latest UI components, uses a more legible font on the menu
 * Old activations of SQL Dependency Tracker now work as expected
 "@
-            
+
             $vs[2].Version | Should Be '2.8.7.512'
             $vs[2].Summary | Should Be 'Updated SQL Compare Engine, Bug Fixes'
             $vs[2].Date | Should Be ([DateTime] '2016-08-01')
@@ -137,7 +137,7 @@ Cool feature
             $vs[2].Blocks.Fixes | Should Be $nul
         }
     }
-    
+
     InModuleScope RedGate.Build {
         Context 'Latest Multiple Versions' {
             $v = Select-ReleaseNotes -ProductName "Test" -Latest -ReleaseNotes @"
@@ -165,6 +165,70 @@ Cool feature
             $v.Blocks.General | Should Be $nul
             $v.Blocks.Features | Should Be '* Updated to the latest SQL Compare engine, version 12, featuring a number of fixes and enhancements.  Removes support for SQL Server 2000 databases.'
             $v.Blocks.Fixes | Should Be '* Latest UI components, fixes initial window position, layout issues and a rare crash'
+        }
+    }
+
+    InModuleScope RedGate.Build {
+        Context 'Strapline Same Priority' {
+            $vs = Select-ReleaseNotes -ProductName "Test" -ReleaseNotes @"
+## 1.2.3.4
+### Strapline
+50.Top
+10.Bottom
+
+## 1.0.0.0
+### Strapline
+10.Also Bottom
+"@
+            $vs.Length | Should Be 2
+            $vs[0].Version | Should Be '1.2.3.4'
+            $vs[0].Summary | Should Be 'Top, Bottom'
+
+            $vs[1].Version | Should Be '1.0.0.0'
+            $vs[1].Summary | Should Be 'Top, Also Bottom, Bottom'
+        }
+    }
+    
+    InModuleScope RedGate.Build {
+        Context 'Older Feature Higher Priority' {
+            $vs = Select-ReleaseNotes -ProductName "Test" -ReleaseNotes @"
+## 1.2.3.4
+### Strapline
+50.Top
+10.Thing
+
+## 1.0.0.0
+### Strapline
+99.Thing
+"@
+            $vs.Length | Should Be 2
+            $vs[0].Version | Should Be '1.2.3.4'
+            $vs[0].Summary | Should Be 'Top, Thing'
+
+            $vs[1].Version | Should Be '1.0.0.0'
+            $vs[1].Summary | Should Be 'Thing, Top'
+        }
+    }
+        
+    InModuleScope RedGate.Build {
+        Context 'Duplicate Priority Older Feature Higher Priority' {
+            $vs = Select-ReleaseNotes -ProductName "Test" -ReleaseNotes @"
+## 1.2.3.4
+### Strapline
+50.Top
+10.Other thing
+10.Thing
+
+## 1.0.0.0
+### Strapline
+99.Thing
+"@
+            $vs.Length | Should Be 2
+            $vs[0].Version | Should Be '1.2.3.4'
+            $vs[0].Summary | Should Be 'Top, Thing, Other thing'
+
+            $vs[1].Version | Should Be '1.0.0.0'
+            $vs[1].Summary | Should Be 'Thing, Top, Other thing'
         }
     }
 }

--- a/Tests/Select-ReleaseNotes.Tests.ps1
+++ b/Tests/Select-ReleaseNotes.Tests.ps1
@@ -118,16 +118,16 @@ Cool feature
             $vs[0].Blocks.Features | Should Be '* Updated to the latest SQL Compare engine, version 12, featuring a number of fixes and enhancements.  Removes support for SQL Server 2000 databases.'
             $vs[0].Blocks.Fixes | Should Be '* Latest UI components, fixes initial window position, layout issues and a rare crash'
 
+            $fixes = '* Updated feature usage reporting library' + [System.Environment]::NewLine + `
+'* Latest UI components, uses a more legible font on the menu' + [System.Environment]::NewLine + `
+'* Old activations of SQL Dependency Tracker now work as expected'
+
             $vs[1].Version | Should Be '2.8.8.523'
             $vs[1].Summary | Should Be 'Updated SQL Compare Engine, Bug Fixes'
             $vs[1].Date | Should Be ([DateTime] '2016-08-11')
             $vs[1].Blocks.General | Should Be $nul
             $vs[1].Blocks.Features | Should Be $nul
-            $vs[1].Blocks.Fixes | Should Be @"
-* Updated feature usage reporting library
-* Latest UI components, uses a more legible font on the menu
-* Old activations of SQL Dependency Tracker now work as expected
-"@
+            $vs[1].Blocks.Fixes | Should Be $fixes
 
             $vs[2].Version | Should Be '2.8.7.512'
             $vs[2].Summary | Should Be 'Updated SQL Compare Engine, Bug Fixes'

--- a/Tests/Select-ReleaseNotes.Tests.ps1
+++ b/Tests/Select-ReleaseNotes.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'Read-ReleaseNotes' {
 
     InModuleScope RedGate.Build {
         Context 'Four Part Version' {
-            Mock Get-Content { '### 1.2.3.4' }
+            Mock Get-Content { '### 1.2.3.4   ' }
             $v = Select-ReleaseNotes -ReleaseNotesPath 'DoesNotExist\RELEASENOTES.md'
             $v.Version | Should Be '1.2.3.4'
             $v.Date | Should Be $nul


### PR DESCRIPTION
New Select-ReleaseNotes for much more advanced RELEASENOTES.md parsing, also has a strapline accumulator for check for updates releases.

Changed behaviour of Read-ReleaseNotes to fail if the n-part version isn't the first encountered (was seeing issues in some RELEASENOTES finding a much lower version that searched due to incorrect match far down the file)