### PR TITLE
Allows dots in strap line

### DIFF
--- a/Public/Select-ReleaseNotes.ps1
+++ b/Public/Select-ReleaseNotes.ps1
@@ -72,7 +72,7 @@ function GetSummary($productName, $release, $accumulator) {
   Date = '^#+\s*.*(?<date>\d\d\d\d.\d\d.\d\d)'
   Header = '^#+\s*(?<header>.+):?$'
   StraplineBlock = '^#+\s*Strapline\s*$'
-  Strapline = '^\s*(?<priority>[0-9]+)\s*-?\s*(?<feature>[^\.]*)\s*$'
+  Strapline = '^\s*(?<priority>[0-9]+)\s*-\s*(?<feature>.*)\s*$'
 
   Example input
   -------------
@@ -190,7 +190,7 @@ function Select-ReleaseNotes {
     $HeaderRegex = '^#+\s*(?<header>.+):?\s*$'
     $DateRegex = '^#+\s*.*(?<date>\d\d\d\d.\d\d.\d\d)'
     $StraplineStartRegex = '^#+\s*Strapline\s*$'
-    $StraplineRegex = '^\s*(?<priority>[0-9]+)\s*-?\s*(?<feature>[^\.]*)\s*$'
+    $StraplineRegex = '^\s*(?<priority>[0-9]+)\s*-\s*(?<feature>.*)\s*$'
 
     $Accumulator = @{}
     $StraplineAccumulator = $false

--- a/Tests/Select-ReleaseNotes.Tests.ps1
+++ b/Tests/Select-ReleaseNotes.Tests.ps1
@@ -178,7 +178,7 @@ Cool feature
 
 ## 1.0.0.0
 ### Strapline
-10 Also Bottom
+10          -              Also Bottom
 "@
             $vs.Length | Should Be 2
             $vs[0].Version | Should Be '1.2.3.4'
@@ -249,6 +249,18 @@ Cool feature
 ### Strapline
 Just trying to put any text here isn't allowed
 "@} | Should Throw
+        }
+    }
+    
+    InModuleScope RedGate.Build {
+        Context 'Version in Strapline' {
+            $v = Select-ReleaseNotes -ProductName "Test" -Latest -ReleaseNotes @"
+## 3.1.1
+### Strapline
+50 - SQL Doc 3.1.1
+"@
+            $v.Version | Should Be '3.1.1'
+            $v.Summary | Should Be 'SQL Doc 3.1.1'
         }
     }
 }


### PR DESCRIPTION
Dots weren't allows to try to prevent "100. Rubbish" which github would render as "1. Rubbish" - now force a dash(-) between the priority and the strap line text instead.