### PR TITLE
Add Dot Cover Process FIlter Argument

### DIFF
--- a/Public/Invoke-DotCoverForExecutable.ps1
+++ b/Public/Invoke-DotCoverForExecutable.ps1
@@ -15,6 +15,8 @@
   Coverage filters for dotCover, to indicate what should and should not be covered.
 .PARAMETER AttributeFilters
   Attribute coverage filters for dotCover, to indicate what should and should not be covered.
+.PARAMETER ProcessFilters
+  Process coverage filters for dotCover, to indicate what should and should not be covered. Requires Dot Cover 2016.2 or later.
 #>
 function Invoke-DotCoverForExecutable {
   [CmdletBinding()]
@@ -36,7 +38,10 @@ function Invoke-DotCoverForExecutable {
     [string] $Filters = '',
 
     [Parameter(Mandatory = $False)]
-    [string] $AttributeFilters = ''
+    [string] $AttributeFilters = '',
+
+    [Parameter(Mandatory = $False)]
+    [string] $ProcessFilters = ''
   )
 
   $DotCoverArguments = @(
@@ -52,6 +57,10 @@ function Invoke-DotCoverForExecutable {
 
   if (![string]::IsNullOrWhiteSpace($AttributeFilters)) {
     $DotCoverArguments += "/AttributeFilters=$AttributeFilters"
+  }
+
+  if (![string]::IsNullOrWhiteSpace($ProcessFilters)) {
+    $DotCoverArguments += "/ProcessFilters=$ProcessFilters"
   }
 
   if ($TargetArguments) {

--- a/Public/Invoke-NUnit3ForAssembly.ps1
+++ b/Public/Invoke-NUnit3ForAssembly.ps1
@@ -42,7 +42,9 @@ function Invoke-NUnit3ForAssembly {
     # The dotcover filters passed to dotcover.exe
     [string] $DotCoverFilters = '',
     # The dotcover filters passed to dotcover.exe
-    [string] $DotCoverAttributeFilters = ''
+    [string] $DotCoverAttributeFilters = '',
+    # The dotcover process filters passed to dotcover.exe. Requires dotcover version 2016.2 or later
+    [string] $DotCoverProcessFilters = ''
   )
 
   Get-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState -Name 'VerbosePreference'
@@ -73,7 +75,8 @@ function Invoke-NUnit3ForAssembly {
         -OutputFile "$AssemblyPath.$TestResultFilenamePattern.coverage.snap" `
         -DotCoverVersion $DotCoverVersion `
         -Filters $DotCoverFilters `
-        -AttributeFilters $DotCoverAttributeFilters
+        -AttributeFilters $DotCoverAttributeFilters `
+        -ProcessFilters $DotCoverProcessFilters
 
     } else {
 

--- a/Public/Invoke-NUnitForAssembly.ps1
+++ b/Public/Invoke-NUnitForAssembly.ps1
@@ -45,6 +45,8 @@ function Invoke-NUnitForAssembly {
     [string] $DotCoverFilters = '',
     # The dotcover filters passed to dotcover.exe
     [string] $DotCoverAttributeFilters = '',
+    # The dotcover process filters passed to dotcover.exe. Requires dotcover version 2016.2 or later
+    [string] $DotCoverProcessFilters = '',
     # If set, do not import test results automatically to Teamcity.
     # In this case it is the responsibility of the caller to call 'TeamCity-ImportNUnitReport "$AssemblyPath.$TestResultFilenamePattern.xml"'
     [switch] $DotNotImportResultsToTeamcity
@@ -83,7 +85,8 @@ function Invoke-NUnitForAssembly {
         -OutputFile "$AssemblyPath.$TestResultFilenamePattern.coverage.snap" `
         -DotCoverVersion $DotCoverVersion `
         -Filters $DotCoverFilters `
-        -AttributeFilters $DotCoverAttributeFilters
+        -AttributeFilters $DotCoverAttributeFilters `
+        -ProcessFilters $DotCoverProcessFilters
 
     } else {
 

--- a/scripts/test-singleassembly.ps1
+++ b/scripts/test-singleassembly.ps1
@@ -33,7 +33,8 @@ param(
     [bool] $EnableCodeCoverage = $false,
     # The version of the nuget package containing DotCover.exe (JetBrains.dotCover.CommandLineTools)
     [string] $DotCoverVersion = '3.2.0',
-    [string] $DotCoverFilters = ''
+    [string] $DotCoverFilters = '',
+    [string] $DotCoverProcessFilters = ''
 )
 
 task TestSingleAssembly {
@@ -49,7 +50,8 @@ task TestSingleAssembly {
     -IncludedCategories $IncludedCategories `
     -EnableCodeCoverage $EnableCodeCoverage `
     -DotCoverVersion $DotCoverVersion `
-    -DotCoverFilters $DotCoverFilters
+    -DotCoverFilters $DotCoverFilters `
+    -DotCoverProcessFilters $DotCoverProcessFilters
 
   Remove-Module RedGate.Build
 }


### PR DESCRIPTION
Add argument so we can pass `/ProcessFilter` argument to dotcover (was added in 2016.2)

Command line reference: https://www.jetbrains.com/help/dotcover/2016.3/dotCover__Console_Runner_Commands.html#cover

We want this to filter out `sqlservr.exe` from our coverage