### PR TITLE
Return blocks in order from Select-ReleaseNotes

### DIFF
--- a/Public/Select-ReleaseNotes.ps1
+++ b/Public/Select-ReleaseNotes.ps1
@@ -212,7 +212,6 @@ function Select-ReleaseNotes {
     $Accumulator = @{}
     $StraplineAccumulator = $false
     $Release = $nul
-    $CurrentBlockIndex = 0;
     
     foreach($Line in $Lines) {
         $Line = $Line.Trim()

--- a/Public/Select-ReleaseNotes.ps1
+++ b/Public/Select-ReleaseNotes.ps1
@@ -28,19 +28,8 @@ function TrimBlocks($release) {
     } 
 }
 
-function FinalizeRelease($release, [string]$productName, $accumulator, $convertBlocksToObject) {
+function FinalizeRelease($release, [string]$productName, $accumulator) {
     TrimBlocks($release)
-
-    if ($convertBlocksToObject) {
-        $blocksObject = @{}
-
-        foreach ($block in $release.Blocks) {
-            $name = $block.Name
-            $blocksObject.$name = $block.Value
-        }
-
-        $release.Blocks = $blocksObject
-    }
     
     # To see the accumulator in action un-comment this line
     # $accumulator.GetEnumerator() | sort {$_.Key} -Descending
@@ -202,9 +191,7 @@ function Select-ReleaseNotes {
         # Only return the top version block in the file
         [switch] $Latest,
         # Product name (if not using strapline this should be set to create a default summary based on at most 3 part version number)
-        [string] $ProductName = $nul,
-        # Return the Blocks collection as an ordered array refleting the order of sections in the input rather than an unordered dictionary
-        [switch] $BlocksInOrder
+        [string] $ProductName = $nul
     )
     if ($ReleaseNotesPath) {
         $Lines = Get-Content $ReleaseNotesPath
@@ -222,8 +209,6 @@ function Select-ReleaseNotes {
     $StraplineStartRegex = '^#+\s*Strapline\s*$'
     $StraplineRegex = '^\s*(?<priority>[0-9]+)\s*-\s*(?<feature>.*)\s*$'
 
-    $convertBlocksToObject = !$BlocksInOrder;
-
     $Accumulator = @{}
     $StraplineAccumulator = $false
     $Release = $nul
@@ -235,7 +220,7 @@ function Select-ReleaseNotes {
         if ($VersionMatch.Success) {
             # If a $Release already was being filled in - clean it up and return it
             if ($Release) {
-                FinalizeRelease -Release $Release -ProductName $ProductName -Accumulator $Accumulator -ConvertBlocksToObject $convertBlocksToObject
+                FinalizeRelease -Release $Release -ProductName $ProductName -Accumulator $Accumulator
 
                 # Return out of the pipeline
                 $Release
@@ -297,7 +282,7 @@ function Select-ReleaseNotes {
 
     # Clean up and return the last $Release object being populated (if there is one)
     if ($Release) {
-        FinalizeRelease -Release $Release -ProductName $ProductName -Accumulator $Accumulator -ConvertBlocksToObject $convertBlocksToObject
+        FinalizeRelease -Release $Release -ProductName $ProductName -Accumulator $Accumulator
         $Release
     }
 }

--- a/Tests/Select-ReleaseNotes.Tests.ps1
+++ b/Tests/Select-ReleaseNotes.Tests.ps1
@@ -263,4 +263,23 @@ Just trying to put any text here isn't allowed
             $v.Summary | Should Be 'SQL Doc 3.1.1'
         }
     }
+
+        InModuleScope RedGate.Build {
+        Context 'Blocks are in correct order with BlockArray' {
+            $v = Select-ReleaseNotes -ProductName "Test" -Latest -BlocksInOrder -ReleaseNotes @"
+## 3.1.1
+### Introduction
+Text
+
+### Features
+Text
+
+### Fixes
+Text
+"@
+            $v.Blocks[0].Name | Should Be 'Introduction'
+            $v.Blocks[1].Name | Should Be 'Features'
+            $v.Blocks[2].Name | Should Be 'Fixes'
+        }
+    }
 }

--- a/Tests/Select-ReleaseNotes.Tests.ps1
+++ b/Tests/Select-ReleaseNotes.Tests.ps1
@@ -8,7 +8,7 @@ Describe 'Select-ReleaseNotes' {
             $v.Version | Should Be '1.2'
             $v.Summary | Should Be 'Test 1.2'
             $v.Date | Should Be $nul
-            $v.Blocks.General | Should Be $nul
+            $v.Blocks.Count | Should Be 0
         }
     }
 
@@ -19,7 +19,7 @@ Describe 'Select-ReleaseNotes' {
             $v.Version | Should Be '1.2.3'
             $v.Summary | Should Be 'Test 1.2.3'
             $v.Date | Should Be $nul
-            $v.Blocks.General | Should Be $nul
+            $v.Blocks.Count | Should Be 0
         }
     }
 
@@ -30,7 +30,7 @@ Describe 'Select-ReleaseNotes' {
             $v.Version | Should Be '1.2.3.4'
             $v.Summary | Should Be 'Test 1.2.3'
             $v.Date | Should Be $nul
-            $v.Blocks.General | Should Be $nul
+            $v.Blocks.Count | Should Be 0
         }
     }
 
@@ -52,9 +52,12 @@ Cool feature
             $v.Version | Should Be '2.8.9'
             $v.Summary | Should Be 'Feature'
             $v.Date | Should Be $nul
-            $v.Blocks.General | Should Be 'General content'
-            $v.Blocks.Features | Should Be 'Cool Feature'
-            $v.Blocks.Fixes | Should Be '* Nasty fix'
+            $v.Blocks[0].Name | Should Be 'General'
+            $v.Blocks[0].Value | Should Be 'General content'
+            $v.Blocks[1].Name | Should Be 'Features'
+            $v.Blocks[1].Value | Should Be 'Cool Feature'
+            $v.Blocks[2].Name | Should Be 'Fixes'
+            $v.Blocks[2].Value | Should Be '* Nasty fix'
         }
     }
 
@@ -67,7 +70,7 @@ Cool feature
             $v.Version | Should Be '5.1.4'
             $v.Summary | Should Be 'SQL Source Control 5.1.4'
             $v.Date | Should Be ([DateTime] '2016-07-08')
-            $v.Blocks.General | Should Be $nul
+            $v.Blocks.Count | Should Be 0
         }
     }
 
@@ -79,7 +82,7 @@ Cool feature
             $v.Version | Should Be '12.0.25.3064'
             $v.Summary | Should Be 'SQL Compare 12.0.25'
             $v.Date | Should Be ([DateTime] '2016-09-13')
-            $v.Blocks.General | Should Be $nul
+            $v.Blocks.Count | Should Be 0
         }
     }
 
@@ -114,9 +117,11 @@ Cool feature
             $vs[0].Version | Should Be '2.8.9'
             $vs[0].Summary | Should Be 'Updated SQL Compare Engine'
             $vs[0].Date | Should Be $nul
-            $vs[0].Blocks.General | Should Be $nul
-            $vs[0].Blocks.Features | Should Be '* Updated to the latest SQL Compare engine, version 12, featuring a number of fixes and enhancements.  Removes support for SQL Server 2000 databases.'
-            $vs[0].Blocks.Fixes | Should Be '* Latest UI components, fixes initial window position, layout issues and a rare crash'
+            $vs[0].Blocks.Count | Should Be 2
+            $vs[0].Blocks[0].Name | Should Be 'Features'
+            $vs[0].Blocks[0].Value | Should Be '* Updated to the latest SQL Compare engine, version 12, featuring a number of fixes and enhancements.  Removes support for SQL Server 2000 databases.'
+            $vs[0].Blocks[1].Name | Should Be 'Fixes'
+            $vs[0].Blocks[1].Value | Should Be '* Latest UI components, fixes initial window position, layout issues and a rare crash'
 
             $fixes = '* Updated feature usage reporting library' + [System.Environment]::NewLine + `
 '* Latest UI components, uses a more legible font on the menu' + [System.Environment]::NewLine + `
@@ -125,16 +130,14 @@ Cool feature
             $vs[1].Version | Should Be '2.8.8.523'
             $vs[1].Summary | Should Be 'Updated SQL Compare Engine, Bug Fixes'
             $vs[1].Date | Should Be ([DateTime] '2016-08-11')
-            $vs[1].Blocks.General | Should Be $nul
-            $vs[1].Blocks.Features | Should Be $nul
-            $vs[1].Blocks.Fixes | Should Be $fixes
+            $vs[1].Blocks.Count | Should Be 1
+            $vs[1].Blocks[0].Name | Should Be 'Fixes'
+            $vs[1].Blocks[0].Value | Should Be $fixes
 
             $vs[2].Version | Should Be '2.8.7.512'
             $vs[2].Summary | Should Be 'Updated SQL Compare Engine, Bug Fixes'
             $vs[2].Date | Should Be ([DateTime] '2016-08-01')
-            $vs[2].Blocks.General | Should Be $nul
-            $vs[2].Blocks.Features | Should Be $nul
-            $vs[2].Blocks.Fixes | Should Be $nul
+            $vs[2].Blocks.Count | Should Be 0
         }
     }
 
@@ -162,9 +165,11 @@ Cool feature
             $v.Version | Should Be '2.8.9'
             $v.Summary | Should Be 'Test 2.8.9'
             $v.Date | Should Be $nul
-            $v.Blocks.General | Should Be $nul
-            $v.Blocks.Features | Should Be '* Updated to the latest SQL Compare engine, version 12, featuring a number of fixes and enhancements.  Removes support for SQL Server 2000 databases.'
-            $v.Blocks.Fixes | Should Be '* Latest UI components, fixes initial window position, layout issues and a rare crash'
+            $v.Blocks.Count | Should Be 2
+            $v.Blocks[0].Name | Should Be 'Features'
+            $v.Blocks[0].Value | Should Be '* Updated to the latest SQL Compare engine, version 12, featuring a number of fixes and enhancements.  Removes support for SQL Server 2000 databases.'
+            $v.Blocks[1].Name | Should Be 'Fixes'
+            $v.Blocks[1].Value | Should Be '* Latest UI components, fixes initial window position, layout issues and a rare crash'
         }
     }
 
@@ -265,21 +270,47 @@ Just trying to put any text here isn't allowed
     }
 
         InModuleScope RedGate.Build {
-        Context 'Blocks are in correct order with BlockArray' {
-            $v = Select-ReleaseNotes -ProductName "Test" -Latest -BlocksInOrder -ReleaseNotes @"
+        Context 'Blocks are in correct order' {
+            $v = Select-ReleaseNotes -ProductName "Test" -Latest -ReleaseNotes @"
 ## 3.1.1
+This is a release
+
 ### Introduction
 Text
 
 ### Features
-Text
+* A feature
 
 ### Fixes
-Text
+* A fix
 "@
-            $v.Blocks[0].Name | Should Be 'Introduction'
-            $v.Blocks[1].Name | Should Be 'Features'
-            $v.Blocks[2].Name | Should Be 'Fixes'
+            $v.Blocks.Count | Should Be 4
+            $v.Blocks[0].Name | Should Be 'General'
+            $v.Blocks[1].Name | Should Be 'Introduction'
+            $v.Blocks[2].Name | Should Be 'Features'
+            $v.Blocks[3].Name | Should Be 'Fixes'
+        }
+    }
+
+# Many existing release scripts call GetEnumerator() on the Blocks object
+        InModuleScope RedGate.Build {
+        Context 'Blocks can be accessed through GetEnumerator' {
+            $v = Select-ReleaseNotes -ProductName "Test" -Latest -ReleaseNotes @"
+## 3.1.1
+### Features
+* A feature
+
+### Fixes
+* A fix
+"@
+            $enumerator = $v.Blocks.GetEnumerator()
+            $enumerator.MoveNext() | Should Be $true
+            $enumerator.Current.Name | Should Be 'Features'
+            $enumerator.Current.Value | Should Be '* A feature'
+            $enumerator.MoveNext() | Should Be $true
+            $enumerator.Current.Name | Should Be 'Fixes'
+            $enumerator.Current.Value | Should Be '* A fix'
+            $enumerator.MoveNext() | Should Be $false
         }
     }
 }


### PR DESCRIPTION
`Select-ReleaseNotes` currently stores each block in the release notes (under a header, e.g. "Features", "Fixes" etc.) indexed as an object property. This is a dictionary, and when release scripts call `GetEnumerator()` on it, the order the blocks is returned is not specified. It appears to be deterministic for a given set of inputs, and returns "General", "Features", "Fixes" in the insertion order, but the addition of another header called "Introduction" messes up the ordering. This means that our release notes were being jumbled up.

This PR makes the `Blocks` property an array of name/value objects rather than an object with properties. As new members are added to the array as the sections are encountered in the release notes, this should mean that the sections are ordered as they first appeared in the input. As far as I can see, all the release scripts that use `Select-ReleaseNotes` call `GetEnumerator()` on `Blocks` and then access its members using `.Name` and `.Value`, so I believe that this won't break any existing consumers, unless they were relying on the previous unspecified ordering.

I have, however, had to update the tests to work with this. I've added an additional test with the `Introduction` case added, and also one that validates that the array can still be accessed with `GetEnumerator()`.