### PR TITLE
NUnit3 where condition

### DIFF
--- a/Public/Invoke-NUnit3ForAssembly.ps1
+++ b/Public/Invoke-NUnit3ForAssembly.ps1
@@ -62,6 +62,7 @@ function Invoke-NUnit3ForAssembly {
     $NunitArguments = Build-NUnit3CommandLineArguments `
       -AssemblyPath $AssemblyPath `
       -x86 $x86.IsPresent `
+      -Where $Where `
       -FrameworkVersion $FrameworkVersion `
       -TestResultFilenamePattern $TestResultFilenamePattern
 

--- a/Tests/Nunit/3/Invoke-NUnit3ForAssembly.Tests.ps1
+++ b/Tests/Nunit/3/Invoke-NUnit3ForAssembly.Tests.ps1
@@ -9,5 +9,15 @@ Describe 'Invoke-NUnit3ForAssembly' {
             { Invoke-NUnit3ForAssembly -Assembly 'myassembly.dll' -NUnitVersion '2.6.4' } | Should Throw "Unexpected NUnit version '2.6.4'. This function only supports Nunit v3"
         }
     }
-
+    
+    Context 'Nunit 3.0.0' {
+        It 'should pass where clause as an argument' {
+            $ExpectedWhereClause = 'cat == TestWhereClause';
+            Mock -ModuleName RedGate.Build Invoke-DotCoverForExecutable { }
+            
+            Invoke-NUnit3ForAssembly -Assembly 'build.ps1' -NUnitVersion '3.0.0' -EnableCodeCoverage $true -Where $ExpectedWhereClause
+            
+            Assert-MockCalled Invoke-DotCoverForExecutable -ModuleName RedGate.Build -Times 1 -ParameterFilter {$TargetArguments -like "*$ExpectedWhereClause*"}
+        }
+    }
 }


### PR DESCRIPTION
Fixes issue with the where condition (used for filtering tests, eg by category) not being passed through as an argument to the NUnit3 command line