### PR TITLE
[breaking] Remove -DoNotCommitChanges parameter from Update-RedgateNugetPackages 

### DIFF
--- a/Public/Update-RedgateNugetPackages.ps1
+++ b/Public/Update-RedgateNugetPackages.ps1
@@ -22,7 +22,7 @@ Function Update-RedgateNugetPackages
         # The name of the branch that will be pushed with any changes
         [string] $UpdateBranchName = 'pkg-auto-update',
 
-        # (Ooptional) github api access token with full repo permissions
+        # (Optional) github api access token with full repo permissions
         # If passed in, changes will be committed, pushed to github and a
         #               pull request will be created/updated.
         # If not set, changes will not be committed. No pull request will be created

--- a/Public/Update-RedgateNugetPackages.ps1
+++ b/Public/Update-RedgateNugetPackages.ps1
@@ -22,8 +22,11 @@ Function Update-RedgateNugetPackages
         # The name of the branch that will be pushed with any changes
         [string] $UpdateBranchName = 'pkg-auto-update',
 
-        # github api access token with full repo permissions
-        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        # (Ooptional) github api access token with full repo permissions
+        # If passed in, changes will be committed, pushed to github and a
+        #               pull request will be created/updated.
+        # If not set, changes will not be committed. No pull request will be created
+        [Parameter(ValueFromPipelineByPropertyName)]
         $GithubAPIToken,
 
         # The root directory of the solution
@@ -57,10 +60,6 @@ Function Update-RedgateNugetPackages
         # the //metadata/dependencies version ranges.
         # Wildcards are supported
         [string[]] $NuspecFiles,
-
-        # (Optional) If set, do not commit/push changes to GitHub and
-        # do not create a pull request. Defaults to $false ie commit the changes
-        [bool] $DoNotCommitChanges = $false
     )
     begin {
         Push-Location $RootDir
@@ -88,8 +87,8 @@ Function Update-RedgateNugetPackages
                 Update-NuspecDependenciesVersions -PackagesConfigPaths $packageConfigFiles.FullName -verbose
         }
 
-        if($DoNotCommitChanges.IsPresent) {
-            Write-Warning "-DoNotCommitChanges was passed in, skip committing changes."
+        if(!$GithubAPIToken) {
+            Write-Warning "-GithubAPIToken was not passed in, skip committing changes."
             return
         }
 

--- a/Public/Update-RedgateNugetPackages.ps1
+++ b/Public/Update-RedgateNugetPackages.ps1
@@ -59,7 +59,7 @@ Function Update-RedgateNugetPackages
         # (Optional) A list of nuspec files for which we will update
         # the //metadata/dependencies version ranges.
         # Wildcards are supported
-        [string[]] $NuspecFiles,
+        [string[]] $NuspecFiles
     )
     begin {
         Push-Location $RootDir


### PR DESCRIPTION
Instead make `-GithubApiToken` optional.

* if `-GithubApiToken` is set, we commit/push changes and create/update a PR
* if `-GithubApiToken` is not set, we do not commit changes

This is going to break any of our build that use `-DoNotCommit` but hey, this should make things simpler?