### PR TITLE
Allow user to specify a package version override

### DIFF
--- a/Public/Update-RedgateNugetPackages.ps1
+++ b/Public/Update-RedgateNugetPackages.ps1
@@ -63,7 +63,8 @@ Function Update-RedgateNugetPackages
         
         # (Optional) A dictionary of package names to versions
         # where the version should be pinned
-        $NuspecPackageVersionOverride = @{}
+        # For example: { NUnit = '2.6.4'; log4net = '2.0.8' }
+        [Hashtable] $NuspecPackageVersionOverride = @{}
     )
     begin {
         Push-Location $RootDir

--- a/Public/Update-RedgateNugetPackages.ps1
+++ b/Public/Update-RedgateNugetPackages.ps1
@@ -59,7 +59,11 @@ Function Update-RedgateNugetPackages
         # (Optional) A list of nuspec files for which we will update
         # the //metadata/dependencies version ranges.
         # Wildcards are supported
-        [string[]] $NuspecFiles
+        [string[]] $NuspecFiles,
+        
+        # (Optional) A dictionary of package names to versions
+        # where the version should be pinned
+        $NuspecPackageVersionOverride = @{}
     )
     begin {
         Push-Location $RootDir
@@ -84,7 +88,10 @@ Function Update-RedgateNugetPackages
         if($NuspecFiles) {
             Resolve-Path $NuspecFiles |
                 Select-Object -ExpandProperty Path |
-                Update-NuspecDependenciesVersions -PackagesConfigPaths $packageConfigFiles.FullName -verbose
+                Update-NuspecDependenciesVersions `
+                    -PackagesConfigPaths $packageConfigFiles.FullName `
+                    -PackageVersionOverride $NuspecPackageVersionOverride `
+                    -Verbose
         }
 
         if(!$GithubAPIToken) {


### PR DESCRIPTION
This is needed when a package has a x.y.z version but isn't actually semvered, e.g. NUnit

 - [ ] Try this In SQL Compare Engine and see if it fixes the nuget update process