### PR TITLE
Simplify nuget updater API

### DIFF
--- a/Public/Update-RedgateNugetPackages.ps1
+++ b/Public/Update-RedgateNugetPackages.ps1
@@ -59,12 +59,7 @@ Function Update-RedgateNugetPackages
         # (Optional) A list of nuspec files for which we will update
         # the //metadata/dependencies version ranges.
         # Wildcards are supported
-        [string[]] $NuspecFiles,
-        
-        # (Optional) A dictionary of package names to versions
-        # where the version should be pinned
-        # For example: { NUnit = '2.6.4'; log4net = '2.0.8' }
-        [Hashtable] $NuspecPackageVersionOverride = @{}
+        [string[]] $NuspecFiles
     )
     begin {
         Push-Location $RootDir
@@ -91,7 +86,7 @@ Function Update-RedgateNugetPackages
                 Select-Object -ExpandProperty Path |
                 Update-NuspecDependenciesVersions `
                     -PackagesConfigPaths $packageConfigFiles.FullName `
-                    -PackageVersionOverride $NuspecPackageVersionOverride `
+                    -DoNotUpdate $ExcludedPackages `
                     -Verbose
         }
 


### PR DESCRIPTION
`Update-RedgateNugetPackages` operates in 2 steps: it updates the dependencies of your solution (*.csproj, *.config) and then it updates the .nuspec files to match the changes it just made.

The user can ignore certain packages when doing this, by using `-ExcludedPackages` which will exclude them from the nuget update step.  Unfortunately that didn't exclude them from the nuspec update, and the nuspec update tends to guess a version range by making assumptions about semantic versioning.  

#64 recently provided a workaround, the `-NuspecPackageVersionOverride` switch, which this PR reverts because it exposed the distinction between the 2 steps rather than abstracting it away.