### PR TITLE
Fix Get-DependencyVersionRange for branches that contain a dash

### DIFF
--- a/Private/Nuget/Get-DependencyVersionRange.ps1
+++ b/Private/Nuget/Get-DependencyVersionRange.ps1
@@ -19,8 +19,8 @@ function Get-DependencyVersionRange
 
     if($Version.Contains('-'))
     {
-        $currentVersion = $Version.Split('-')[0]
-        $branchSuffix = "-$($Version.Split('-')[1])"
+        $currentVersion = $Version.Split('-', 2)[0]
+        $branchSuffix = "-$($Version.Split('-', 2)[1])"
     } else
     {
         $currentVersion = $Version

--- a/Tests/Nuget/Get-DependencyVersionRange.Tests.ps1
+++ b/Tests/Nuget/Get-DependencyVersionRange.Tests.ps1
@@ -29,4 +29,8 @@ Describe 'Get-DependencyVersionRange' {
     It 'should handle a 3 part number version with suffix' {
         Get-DependencyVersionRange '1.2.3-suffix' -verbose | Should Be '[1.2.3-suffix, 2.0.0-suffix)'
     }
+
+    It 'should handle a 3 part version with suffix where the suffix contains a dash' {
+        Get-DependencyVersionRange '1.2.3-suffix-b' -verbose | Should Be '[1.2.3-suffix-b, 2.0.0-suffix-b)'
+    }
 }


### PR DESCRIPTION
This was causing broken nuspec files (eg [this backupreader package](http://nuget.red-gate.com/packages/RedGate.BackupReader/3.1.62-update-shsql-remove-) had a dependency on `RedGate.Shared.SQL (>= 19.0.6-remove-executionbloc && < 20.0.0-remove)`)

I think this got caught by the nuget dependency tests in CompareEngine when we tried to update that package; once we can generate correct packages we can see if this solves the test failures