### PR TITLE
Add nunit 2.5.9 support

### DIFF
--- a/Private/NUnit/2/Build-NUnitCommandLineArguments.ps1
+++ b/Private/NUnit/2/Build-NUnitCommandLineArguments.ps1
@@ -10,7 +10,7 @@ function Build-NUnitCommandLineArguments {
     )
 
     $params = $AssemblyPath,
-        "/result=`"$AssemblyPath.$TestResultFilenamePattern.xml`"",
+        "/xml=`"$AssemblyPath.$TestResultFilenamePattern.xml`"",
         '/nologo',
         '/nodots',
         '/noshadow',

--- a/Tests/Nunit/2/Build-NUnitCommandLineArguments.Tests.ps1
+++ b/Tests/Nunit/2/Build-NUnitCommandLineArguments.Tests.ps1
@@ -7,7 +7,7 @@ $FullPathToModuleRoot = Resolve-Path $PSScriptRoot\..\..\..
 Describe 'Build-NUnitCommandLineArguments' {
 
     function Nunit2Parameters($assembly, $TestResult = 'TestResult') {
-        "$assembly /result=`"$assembly.$TestResult.xml`" /nologo /nodots /noshadow /labels /out:`"$assembly.$TestResult.TestOutput.txt`" /err:`"$assembly.$TestResult.TestError.txt`""
+        "$assembly /xml=`"$assembly.$TestResult.xml`" /nologo /nodots /noshadow /labels /out:`"$assembly.$TestResult.TestOutput.txt`" /err:`"$assembly.$TestResult.TestError.txt`""
     }
 
     Context 'With minimum arguments' {


### PR DESCRIPTION
`/xml=` is understood by older versions of nunit 2. `/result=` isn't.