### PR TITLE
Added Test-NugetPackage cmdlet

### DIFF
--- a/Public/Nuget/Test-NugetPackage.ps1
+++ b/Public/Nuget/Test-NugetPackage.ps1
@@ -25,7 +25,7 @@ function Test-NugetPackage
     )
 
     try {
-        $PackagePath = Install-Package -Name $Name -Version $Version -ErrorAction SilentlyContinue
+        $PackagePath = Install-Package -Name $Name -Version $Version -Silent
         return $PackagePath -ne $Null
     } catch {
         return $False

--- a/Public/Nuget/Test-NugetPackage.ps1
+++ b/Public/Nuget/Test-NugetPackage.ps1
@@ -1,0 +1,33 @@
+<#
+        .SYNOPSIS
+        Determines whether or not a specific version of a Nuget Package exists.
+        .DESCRIPTION
+        Determines whether or not a specific version of a Nuget Package exists.
+        Currently attempt to install the package, returning $True if successful and
+        $False on error.
+        .PARAMETER Name
+        The name/id of the nuget package to test for.
+        .PARAMETER Version
+        The version of the nuget package to test for.
+        .OUTPUTS
+        $True if the package exists. $False if not.
+#>
+#requires -Version 2
+function Test-NugetPackage
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Name,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Version
+    )
+
+    try {
+        $PackagePath = Install-Package -Name $Name -Version $Version -ErrorAction SilentlyContinue
+        return $PackagePath -ne $Null
+    } catch {
+        return $False
+    }
+}

--- a/Tests/Nuget/Test-NugetPackage.Tests.ps1
+++ b/Tests/Nuget/Test-NugetPackage.Tests.ps1
@@ -1,0 +1,19 @@
+#requires -Version 4 -Modules Pester
+
+Describe 'Test-NugetPackage' {
+
+    It "should return `$True for a package version that exists" {
+        $result = Test-NugetPackage -Name Newtonsoft.Json -Version 9.0.1
+        $result | Should Be $True
+    }
+
+    It "should return `$False for a package that doesn't exist" {
+        $result = Test-NugetPackage -Name Totally.Made.Up.Package -Version 1.0.0
+        $result | Should Be $False
+    }
+
+    It "should return `$False for a package that exists, but the version doesn't exist" {
+        $result = Test-NugetPackage -Name Newtonsoft.Json -Version 9999.9999.9999
+        $result | Should Be $False
+    }
+}


### PR DESCRIPTION
Cmdlet used to determine whether or not a specific version of a package exists.

Normally one would use the `nuget.exe list` command, but there's [a long-standing unfixed bug](https://github.com/NuGet/NuGetGallery/issues/3274) that prevents this. This cmdlet provides an alternative method for detecting the presence or absence of a specific package, without having to resort to manually invoking `nuget.exe list`, scraping the output, then realising it's buggy.

The current implementation simply invokes `Install-Package` and then checks to see whether the operation succeeds or fail. Whilst the Pester tests passed, unfortunately this triggered TeamCity build failures because the console error output produced by `nuget.exe` when checking for a non-existent package was interpreted as a sign of a build failure. To work around this, I've modified `Install-Package` to provide a `-Silent` parameter that suppresses error output.