### PR TITLE
Remove --teamcity when calling nunit3-console.exe

### DIFF
--- a/Private/NUnit/3/Build-NUnit3CommandLineArguments.ps1
+++ b/Private/NUnit/3/Build-NUnit3CommandLineArguments.ps1
@@ -11,7 +11,6 @@ function Build-NUnit3CommandLineArguments {
 
     $params = $AssemblyPath,
         "--result=`"$AssemblyPath.$TestResultFilenamePattern.xml`"",
-        "--teamcity",
         "--noheader",
         "--labels=On",
         "--out=`"$AssemblyPath.$TestResultFilenamePattern.TestOutput.txt`"",

--- a/Public/Invoke-NUnit3ForAssembly.ps1
+++ b/Public/Invoke-NUnit3ForAssembly.ps1
@@ -91,7 +91,7 @@ function Invoke-NUnit3ForAssembly {
       Publish-ResultsAndLogsToTeamcity `
         -AssemblyPath $AssemblyPath `
         -TestResultFilenamePattern $TestResultFilenamePattern `
-        -ImportResultsToTeamcity $false # Do not import results to Teamcity since we are already executing nunit with the --teamcity switch
+        -ImportResultsToTeamcity $false # Do not import results to Teamcity since NUnit 3 used service messages to integrate with Teamcity on its own.
   }
 
 }

--- a/Tests/Nunit/3/Build-NUnit3CommandLineArguments.Tests.ps1
+++ b/Tests/Nunit/3/Build-NUnit3CommandLineArguments.Tests.ps1
@@ -7,7 +7,7 @@ $FullPathToModuleRoot = Resolve-Path $PSScriptRoot\..\..\..
 Describe 'Build-NUnit3CommandLineArguments' {
 
     function Nunit3Parameters($assembly, $TestResult = 'TestResult') {
-        "$assembly --result=`"$assembly.$TestResult.xml`" --teamcity --noheader --labels=On --out=`"$assembly.$TestResult.TestOutput.txt`" --err=`"$assembly.$TestResult.TestError.txt`""
+        "$assembly --result=`"$assembly.$TestResult.xml`" --noheader --labels=On --out=`"$assembly.$TestResult.TestOutput.txt`" --err=`"$assembly.$TestResult.TestError.txt`""
     }
 
     Context 'With minimum arguments' {


### PR DESCRIPTION
NUnit3 detects whether it's being executed from Teamcity and does the right thing already.

Removing this will avoid build logs being polluted with Teamcity service messages if we decide to use other CI servers...

Tested and confirmed it is working against a build using NUnit v3.7