### PR TITLE
Consistency with `TeamCity-SetBuildNumber`

### DIFF
--- a/Private/CIServers.psm1
+++ b/Private/CIServers.psm1
@@ -9,7 +9,7 @@ function Get-CIServer {
 function Write-CIBuildNumber([string]$buildNumber) {
     & "Write-$(Get-CIServer)BuildNumber" $buildNumber
 }
-Set-Alias CI-BuildNumber Write-CIBuildNumber
+Set-Alias CI-SetBuildNumber Write-CIBuildNumber
 
 function Write-CIImportNUnitReport([Parameter(ValueFromPipeline)][string]$path) {
     process {

--- a/Private/CIServers/vsts.psm1
+++ b/Private/CIServers/vsts.psm1
@@ -1,7 +1,7 @@
 function Write-VSTSBuildNumber([string] $buildNumber) {
     Write-VSTSLoggingCommand 'build.updatebuildnumber' $buildNumber
 }
-Set-Alias VSTS-BuildNumber Write-VSTSBuildNumber
+Set-Alias VSTS-SetBuildNumber Write-VSTSBuildNumber
 
 function Write-VSTSImportNUnitReport([Parameter(ValueFromPipeline)][string]$path) {
 	process {

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,7 +1,7 @@
 # 0.3
 
 - Add support for Powershell files to `Invoke-SigningService` [#77](https://github.com/red-gate/RedGate.Build/pull/77)
-- Add new helper functions to write integration messages to CI servers other than Teamcity [#74](https://github.com/red-gate/RedGate.Build/pull/74)
+- Add new helper functions to write integration messages to CI servers other than Teamcity [#74](https://github.com/red-gate/RedGate.Build/pull/74), [#78](https://github.com/red-gate/RedGate.Build/pull/78)
     - VSTS
         - `Write-VSTSBuildNumber` (alias: `VSTS-BuildNumber`)
         - `Write-VSTSImportNUnitReport` (alias: `VSTS-ImportNUnitReport`)


### PR DESCRIPTION
This PR changes the names of two of the new functions added in https://github.com/red-gate/RedGate.Build/pull/74 to ensure consistency with `TeamCity-SetBuildNumber`

https://github.com/red-gate/RedGate.Build/blob/f059c64e0975a5176f9b62d170b24a150ad76056/Private/CIServers/teamcity.psm1#L154

In particular, the word **Set** in the function name.