### PR TITLE
More VSTS / NUnit tweaks

### DIFF
--- a/Private/NUnit/Publish-ResultsAndLogs.ps1
+++ b/Private/NUnit/Publish-ResultsAndLogs.ps1
@@ -8,7 +8,7 @@ function Publish-ResultsAndLogs {
     )
 
     if($ImportResultsToCIServer) {
-      TeamCity-ImportNUnitReport "$AssemblyPath.$TestResultFilenamePattern.xml"
+      CI-ImportNUnitReport "$AssemblyPath.$TestResultFilenamePattern.xml"
     }
 
     # Tell teamcity to keep our test output logs as well. This could come in handy

--- a/Public/Invoke-NUnit3ForAssembly.ps1
+++ b/Public/Invoke-NUnit3ForAssembly.ps1
@@ -88,10 +88,11 @@ function Invoke-NUnit3ForAssembly {
     }
 
   } finally {
+      [bool] $isTeamcity = (Get-CIServer) -eq 'Teamcity'
       Publish-ResultsAndLogs `
         -AssemblyPath $AssemblyPath `
         -TestResultFilenamePattern $TestResultFilenamePattern `
-        -ImportResultsToCIServer $false # Do not import results to Teamcity since NUnit 3 uses service messages to integrate with Teamcity on its own.
+        -ImportResultsToCIServer (!$isTeamcity) # Do not import results to Teamcity since NUnit 3 uses service messages to integrate with Teamcity on its own.
   }
 
 }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,6 @@
 # 0.3
 
+- `Invoke-NUnitForAssembly` and `Invoke-NUnit3ForAssembly` can now import test results in both Teamcity and VSTS [#79](https://github.com/red-gate/RedGate.Build/pull/79)
 - Add support for Powershell files to `Invoke-SigningService` [#77](https://github.com/red-gate/RedGate.Build/pull/77)
 - Add new helper functions to write integration messages to CI servers other than Teamcity [#74](https://github.com/red-gate/RedGate.Build/pull/74), [#78](https://github.com/red-gate/RedGate.Build/pull/78)
     - VSTS


### PR DESCRIPTION
* `Publish-ResultsAndLogs` can now import NUnit results in both Teamcity and VSTS.
* Make sure we do allow `Publish-ResultsAndLogs` to import results when not running from Teamcity.