### PR TITLE
Upgrade Invoke-Build to 4

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,5 +1,5 @@
 source https://nuget.org/api/v2
 
 nuget Nuget.CommandLine ~> 4
-nuget Invoke-Build ~> 3
+nuget Invoke-Build ~> 4
 nuget Pester ~> 4.0.8


### PR DESCRIPTION
Looking at the [Invoke-Build release notes](https://github.com/nightroman/Invoke-Build/blob/v4.0.0/Release-Notes.md#v400), nothing that significant happened at 4.0.0, so we should just upgrade.

(Also, now [my PR to Invoke-Build](https://github.com/nightroman/Invoke-Build/pull/107) is merged, we need to upgrade Invoke-Build for me to benefit from it :smile:)