### PR TITLE
Do not exclude RedGate.Client.ActivationPluginShim when updating nuget packages

### DIFF
--- a/Public/Update-RedgateNugetPackages.ps1
+++ b/Public/Update-RedgateNugetPackages.ps1
@@ -70,10 +70,6 @@ Function Update-RedgateNugetPackages
     {
         $packageConfigFiles = GetNugetPackageConfigs -RootDir $RootDir
 
-        if(!$ExcludedPackages) { $ExcludedPackages = @() }
-        # temporarily excluded package. 2.0 to 2.1 changes behavior.
-        $ExcludedPackages += 'RedGate.Client.ActivationPluginShim'
-
         $RedgatePackageIDs = GetNugetPackageIds `
             -PackageConfigs $packageConfigFiles `
             -IncludedPackages $IncludedPackages `


### PR DESCRIPTION
This reverts a9dc3d5f2ef which was meant to be a temporary hack <cough>11 months ago<cough> :disappointed:

I would hope everything should work as expected and we're better off excluding that package explicitely when calling `Update-RedgateNugetPackages` (if we really need to) rather than forgetting we've got a special case in here....