### PR TITLE
Add support for new csproj in update package

### DIFF
--- a/Public/Update-RedgateNugetPackages.ps1
+++ b/Public/Update-RedgateNugetPackages.ps1
@@ -183,11 +183,11 @@ function UpdatePackageReferences([string]$RootDir, [string[]]$IncludedPackages, 
     Get-ChildItem $RootDir -Filter *.csproj -Recurse | % { 
         $file = $_.FullName
         $packages = @()
-        (Get-Content $_.FullName | % {
-            if ($_  -match "<PackageReference Include=`"(?<PackageName>[\.\w]+)`" Version=`"(?<PackageVersion>[\d\.]+)`"") {
-                $packages = $packages + @(@{ Name = $Matches.PackageName; Version = $Matches.PackageVersion })
-            }
-        })
+        $xml = [xml](Get-Content $_.FullName)
+
+        (Select-Xml "//PackageReference" $xml).Node | % {
+            $packages = $packages + @(@{ Name = $_.Include; Version = $_.Version })
+        }
         
         $filteredPackages = @()
         foreach($pattern in $IncludedPackages) {

--- a/Public/Update-RedgateNugetPackages.ps1
+++ b/Public/Update-RedgateNugetPackages.ps1
@@ -71,6 +71,8 @@ Function Update-RedgateNugetPackages
         $UpdatedPackages = UpdatePackageConfigs -RootDir $RootDir -Solution $Solution -IncludedPackages $IncludedPackages -ExcludedPackages $ExcludedPackages -NuspecFiles $NuspecFiles
         
         $UpdatedPackages += UpdatePackageReferences -RootDir $RootDir -IncludedPackages $IncludedPackages -ExcludedPackages $ExcludedPackages
+        
+        $UpdatedPackages = $UpdatedPackages | Select -Unique
 
         if(!$GithubAPIToken) {
             Write-Warning "-GithubAPIToken was not passed in, skip committing changes."

--- a/Public/Update-RedgateNugetPackages.ps1
+++ b/Public/Update-RedgateNugetPackages.ps1
@@ -219,7 +219,7 @@ function UpdatePackageReferences([string]$RootDir, [string[]]$IncludedPackages, 
                 Pop-Location
             }
         
-            $updatedPackages | Select -Unique | Write-Output
+            $updatedPackages | Write-Output
         }
-    }
+    } | Select -Unique
 }

--- a/Public/Update-RedgateNugetPackages.ps1
+++ b/Public/Update-RedgateNugetPackages.ps1
@@ -151,6 +151,10 @@ function GetNugetPackageIds(
 
 function UpdatePackageConfigs([string]$RootDir, [string]$Solution, [string[]]$IncludedPackages, [string[]]$ExcludedPackages, [string[]] $NuspecFiles) {
     $packageConfigFiles = GetNugetPackageConfigs -RootDir $RootDir
+    
+    if (-not $packageConfigFiles) {
+        return
+    }
 
     $RedgatePackageIDs = GetNugetPackageIds `
         -PackageConfigs $packageConfigFiles `


### PR DESCRIPTION
Adds support for new csproj format when updating packages.

Requires being able to run dotnet tools against any csproj using the new `PackageReference` syntax.

This will only run if there is a `PackageReference` so shouldn't affect most tools. I tested it against DLM Automation. Also prevents failure if there are no package configs in the repo