### PR TITLE
Fix "PR already exists" errors

### DIFF
--- a/Public/GitHub/Get-PullRequest.ps1
+++ b/Public/GitHub/Get-PullRequest.ps1
@@ -36,13 +36,13 @@ function Get-PullRequest
             -Uri "https://api.github.com/repos/red-gate/$Repo/pulls?head=red-gate:$Head&base=$Base" `
             -Headers @{Authorization="token $Token"} `
             -Method Get
-    }
 
-    if($prs.length -eq 0)
-    {
-        return $null
-    }
+        if($prs.length -eq 0)
+        {
+            return $null
+        }
     
-    return $prs[0]
+        return $prs[0]
+    }
 }
 

--- a/Public/GitHub/New-PullRequest.ps1
+++ b/Public/GitHub/New-PullRequest.ps1
@@ -54,12 +54,10 @@ $Data
 "@
 
     Use-Tls {
-        $result = Invoke-RestMethod `
+        return Invoke-RestMethod `
             -Uri "https://api.github.com/repos/red-gate/$Repo/pulls" `
             -Headers @{Authorization="token $Token"} `
             -Method Post `
             -Body $Data
     }
-
-    return $result
 }

--- a/Public/GitHub/Update-PullRequest.ps1
+++ b/Public/GitHub/Update-PullRequest.ps1
@@ -41,14 +41,12 @@ Function Update-PullRequest
         $PayloadJson = $Payload | ConvertTo-Json
 
         Use-Tls {
-            $result = Invoke-RestMethod `
+            return Invoke-RestMethod `
                     -Uri "https://api.github.com/repos/red-gate/$Repo/issues/$Number" `
                     -Headers @{Authorization="token $Token"} `
                     -Method Patch `
                     -Body $PayloadJson
         }
-
-        return $result
     }
 }
 

--- a/Tests/Use-Tls.Tests.ps1
+++ b/Tests/Use-Tls.Tests.ps1
@@ -7,6 +7,9 @@ Describe 'Use-Tls' {
                 [Net.ServicePointManager]::SecurityProtocol -band [Net.SecurityProtocolType]::Tls12 | Should -Be ([Net.SecurityProtocolType]::Tls12)
             }
         }
+        It 'Should return whatever the delegate returns' {
+            Use-Tls { return 2; } | Should -Be 2
+        }
     }
     Context 'When given a delegate that throws' {
         It 'should cause the exception to be thrown' {


### PR DESCRIPTION
The previous PR introduced the `Use-Tls { .... }` function but mangled the return values:
```
Use-Tls {
    $result = Invoke-RestMethod ...
}
return $result
```
Unfortunately the result is no longer in scope, so this code always returns null.  In this PR we move the return statement inside the `Use-Tls` block, and add a test to assert that return values will be passed through to the calling method.