### PR TITLE
Write the list of updated packages out

### DIFF
--- a/Public/Update-RedgateNugetPackages.ps1
+++ b/Public/Update-RedgateNugetPackages.ps1
@@ -73,6 +73,8 @@ Function Update-RedgateNugetPackages
         $UpdatedPackages += UpdatePackageReferences -RootDir $RootDir -IncludedPackages $IncludedPackages -ExcludedPackages $ExcludedPackages
         
         $UpdatedPackages = $UpdatedPackages | Select -Unique
+        
+        Write-Output $UpdatedPackages
 
         if(!$GithubAPIToken) {
             Write-Warning "-GithubAPIToken was not passed in, skip committing changes."


### PR DESCRIPTION
In SoC we run the following code:

```
$UpdatePackages = Update-RedgateNugetPackages -Repo 'SQLSourceControl' `
        -GithubAPIToken $GithubAPIToken `
        -RootDir $RootDir `
        -Solution $Solution `
        -ExcludedPackages $ExcludedPackages `
        -Labels @('needs code review', 'awaiting TC test run', 'needs release notes') `
        -UpdateBranchName $UpdateBranch |
        Tee-Object -FilePath $OutputDir\nuget-auto-update.log.txt
```

Following recent changes this appears to always return `null`. Since we need this to do further work if `Honeycomb.WPF` is updated this change is a slightly speculative update to restore this behaviour.