### PR TITLE
Add support to Invoke-SigningService for signing libs in NuGet packages

### DIFF
--- a/Public/Invoke-SigningService.ps1
+++ b/Public/Invoke-SigningService.ps1
@@ -188,7 +188,7 @@ function Invoke-SigningServiceForNuGetPackage {
             ForEach-Object {
                 Write-Verbose "Signing $($_.FullName.Substring($ContentsDir.Length + 1))"
                 if ($HashAlgorithm) {
-                    $Null = Invoke-SigningService `
+                    Invoke-SigningService `
                         -FilePath $_.FullName `
                         -SigningServiceUrl $SigningServiceUrl `
                         -Certificate $Certificate `
@@ -197,7 +197,7 @@ function Invoke-SigningServiceForNuGetPackage {
                         -MoreInfoUrl $MoreInfoUrl `
                         -Force:$Force.IsPresent
                 } else {
-                    $Null = Invoke-SigningService `
+                    Invoke-SigningService `
                         -FilePath $_.FullName `
                         -SigningServiceUrl $SigningServiceUrl `
                         -Certificate $Certificate `

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,7 @@
+# 0.4
+
+- `Invoke-SigningService` will now accept a NuGet package. The NuGet package is not directly signed itself. Instead, it is unpacked to a temporary folder, all the assembly dlls in the `lib` sub-folder are signed by the signing service, and then the NuGet package is reassembled. 
+
 # 0.3
 
 - `Invoke-NUnitForAssembly` and `Invoke-NUnit3ForAssembly` can now import test results in both Teamcity and VSTS [#79](https://github.com/red-gate/RedGate.Build/pull/79)

--- a/Tests/Invoke-SigningService.Tests.ps1
+++ b/Tests/Invoke-SigningService.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'Invoke-SigningService' {
         It 'should fail if $env:SigningServiceUrl is not set' {
             $env:SigningServiceUrl = $null
             {$testExeFile | Invoke-SigningService} |
-                Should Throw 'Cannot sign assembly. -SigningServiceUrl was not specified and the SigningServiceUrl environment variable is not set.'
+                Should Throw 'Cannot sign file. -SigningServiceUrl was not specified and the SigningServiceUrl environment variable is not set.'
         }
     }
 


### PR DESCRIPTION
**What does this PR do?**

Adds support for calling `Invoke-SigningService` with a NuGet package. The cmdlet then signs any assembly dlls within the `libs` sub-folder of the package.

**Why?**

To date, many build scripts contain the following three separate steps.

1. Compile a solution.
2. Invoke the signing service on specific assembly dlls that were built in step 1.
3. Generate the NuGet packages based on manually maintained `.nuspec` files.

With a gradual move to .NET Standard, .NET Core, the new VS 2017 project format, and multi-platform targeting, steps 1 and 3 are now carried out at the same time by msbuild and the dotnet cli tools. This no longer leaves us with a clean opportunity to sign the assembly dlls after they've been created, but before they've been packaged into a NuGet package.

This new functionality allows us to perform the assembly signing after msbuild has done its job of building and packaging them.

**What alternatives were considered?**

- Hook into the msbuild process and invoke the signing after the assemblies have been built, but before they're packaged into a NuGet package. Rejected because this feels a bit too much like the old build magic. It's overly intrusive into the build process, and potentially slows the builds during development.

- Update the signing service so that it can sign the NuGet packages, whereby it would unpack the NuGet package, sign the assemblies, then rebuild the package. Rejected mainly because performing this work on the client means it's more transparent to our users (i.e. devs in the product division). For example, if someone decides that they don't want all assemblies in the `lib` folder to be signed, changing the behaviour in the client is more straightforward than chaning the server.

**How's it tested?**

Manually. The existing tests for `Invoke-SigningService` aren't particularly comprehensive. Maybe we should explore ways to make this more testable?

Update: I've retested this manually after the code review changes. All seems good. Would still be nice to craft some automated checks. Will save than for another PR.