### PR TITLE
Improved handling of errors in the signing request

### DIFF
--- a/Public/Invoke-SigningService.ps1
+++ b/Public/Invoke-SigningService.ps1
@@ -179,27 +179,46 @@ Use sha1 if targeting VS 2013 and older. Use sha256 if targeting VS 2015+
         '.psm1' { $fileType = 'PowerShell' }
         default { throw "Unsupported file type: $FilePath" }
     }
+    
+    $TempDir = New-TempDir
+    try {
+        # The output file from the signing service. We don't overwrite the original until the response has been validated.
+        $OutFilePath = "$TempDir\$([IO.Path]::GetFileName($FilePath))"
+        
+        # Make the web request to the signing service.
+        $Headers = @{};
+        Add-ToHashTableIfNotNull $Headers -Key 'FileType' -Value $FileType
+        Add-ToHashTableIfNotNull $Headers -Key 'Certificate' -Value $Certificate
+        Add-ToHashTableIfNotNull $Headers -Key 'Description' -Value $Description
+        Add-ToHashTableIfNotNull $Headers -Key 'MoreInfoUrl' -Value $MoreInfoUrl
+        Add-ToHashTableIfNotNull $Headers -Key 'HashAlgorithm' -Value $HashAlgorithm
 
-    # Make the web request to the signing service.
-    $Headers = @{};
-    Add-ToHashTableIfNotNull $Headers -Key 'FileType' -Value $FileType
-    Add-ToHashTableIfNotNull $Headers -Key 'Certificate' -Value $Certificate
-    Add-ToHashTableIfNotNull $Headers -Key 'Description' -Value $Description
-    Add-ToHashTableIfNotNull $Headers -Key 'MoreInfoUrl' -Value $MoreInfoUrl
-    Add-ToHashTableIfNotNull $Headers -Key 'HashAlgorithm' -Value $HashAlgorithm
+        Write-Verbose "Signing $FilePath using $SigningServiceUrl"
+        $Headers.Keys | ForEach-Object { Write-Verbose "`t $_`: $($Headers[$_])" }
 
-    Write-Verbose "Signing $FilePath using $SigningServiceUrl"
-    $Headers.Keys | ForEach-Object { Write-Verbose "`t $_`: $($Headers[$_])" }
-
-    $Response = Invoke-WebRequest `
-        -Uri $SigningServiceUrl `
-        -InFile $FilePath `
-        -OutFile $FilePath `
-        -Method Post `
-        -ContentType 'binary/octet-stream' `
-        -Headers $Headers
-
-    # TODO: How should we check the response? Need to fail if the signing failed.
+        Invoke-WebRequest `
+            -Uri $SigningServiceUrl `
+            -InFile $FilePath `
+            -OutFile $OutFilePath `
+            -Method Post `
+            -ContentType 'binary/octet-stream' `
+            -Headers $Headers
+        
+        # The signing service guarantees an error response if anything went wrong with signing,
+        # so if we've got here, it's a good sign that the signing request succeeded.
+        # See https://github.com/red-gate/SigningService/blob/master/SigningService/Controllers/HomeController.cs#L29
+        
+        # Sanity check the signature, as it's the only way we can be absolutely sure the signing worked.
+        if ((Get-AuthenticodeSignature $OutFilePath).Status -ne 'Valid') {
+            throw 'Signature validation failed on the file returned by the signing service'
+        }
+        
+        # And finally overwrite the original input file with the signed version.
+        Move-Item -Path $OutFilePath -Destination $FilePath -Force
+    } finally {
+        # Clean up.
+        Remove-Item $TempDir -Recurse -Force
+    }
 }
 
 function Invoke-SigningServiceForNuGetPackage {

--- a/Tests/Invoke-SigningService.Tests.ps1
+++ b/Tests/Invoke-SigningService.Tests.ps1
@@ -7,15 +7,19 @@ Describe 'Invoke-SigningService' {
 
     Context '-SigningServiceUrl is not passed in' {
 
-
         It 'should use value of $env:SigningServiceUrl' {
-            Mock Invoke-WebRequest {} `
+            Mock Invoke-WebRequest `
                 -Module RedGate.Build `
                 -Verifiable `
                 -ParameterFilter { $Uri -eq 'https://mysigningservice.example.com' }
 
+            Mock Get-AuthenticodeSignature { return @{Status = 'Valid'} } `
+                -Module RedGate.Build
+
+            Mock Move-Item -Module RedGate.Build
+
             $env:SigningServiceUrl = 'https://mysigningservice.example.com'
-            $testExeFile | Invoke-SigningService
+            $testExeFile | Invoke-SigningService -Force
 
             Assert-VerifiableMock
         }


### PR DESCRIPTION
Addressed an outstanding TODO comment about checking for errors in the signing request. This included:

- Checking the code in the signing service to become convinced that, if the signing fails, an error response is guaranteed.
- Manually testing that the Invoke-WebRequest does indeed raise an error when the signing service returns an error response. Together with the above, this means we're now confident that, when the request succeeds, the response does indeed contain a correctly signed file.
- Explicitly checking the certificate on the returned file. Mainly this guards against a success response, where the response body content was in some way not correctly received in full.
- Saving the response to a temp file, and only overwriting the original input file once we're happy the request succeeded. This ensures that we avoid overwriting the original with a serialised `BasicHtmlWebResponseObject`, or some other such unknown content, which is what happens when the response fails (see `help Invoke-WebRequest -Parameter OutFile`).

Arguably the code is now a bit paranoid, but I suggest that's probably a good thing in this area. If it causes stability problems in practice, we can revert this change and revisit the issue.