### PR TITLE
New `Update-ProjectProperties` cmdlet

### DIFF
--- a/Public/Update-ProjectProperties.ps1
+++ b/Public/Update-ProjectProperties.ps1
@@ -1,0 +1,87 @@
+<#
+.SYNOPSIS
+  Updates various properties in a VS2017-style project file.
+
+.DESCRIPTION
+  Updates various properties in a VS2017-style project file, including the Version, AssemblyVersion, FileVersion and PackageReleaseNotes.
+
+.PARAMETER Path
+  The path of the project file to update.
+
+.PARAMETER Version
+  The Version of the project, this defines the version of any output NuGet package. Is equivalent to the value of the AssemblyInformationalVersionAttribute.
+
+.PARAMETER AssemblyVersion
+  The AssemblyVersion of the project, this defines the runtime compatibility version of the output assembly. Is equivalent to the value of the AssemblyVersionAttribute.
+
+.PARAMETER FileVersion
+  The FileVersion of the project, this defines the file version of the output assembly. Is equivalent to the value of the AssemblyFileVersionAttribute.
+
+.PARAMETER PackageReleaseNotes
+  The PackageReleaseNotes of the project, this defines the release notes for any output NuGet package.
+
+.OUTPUTS
+  The input Path parameter, to facilitate command chaining.
+#>
+function Update-ProjectProperties
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $True, Position = 0, ValueFromPipeLine = $True)]
+        [string] $Path,
+
+        [Parameter(Mandatory = $False)]
+        [string] $Version,
+
+        [Parameter(Mandatory = $False)]
+        [version] $AssemblyVersion,
+
+        [Parameter(Mandatory = $False)]
+        [version] $FileVersion,
+
+        [Parameter(Mandatory = $False)]
+        [string] $PackageReleaseNotes
+    )
+
+    if (-not (Test-Path $Path)) {
+        throw "Project file not found: $Path"
+    }
+
+    $ProjectXml = [xml] (Get-Content $Path)
+    $PropertyGroupElement = $ProjectXml.SelectSingleNode('/Project[@Sdk]/PropertyGroup[1]')
+    if ($PropertyGroupElement) {
+        Write-Verbose "Updating properties in project file $Path"
+        Update-Property $ProjectXml $PropertyGroupElement 'Version' $Version
+        Update-Property $ProjectXml $PropertyGroupElement 'AssemblyVersion' $AssemblyVersion
+        Update-Property $ProjectXml $PropertyGroupElement 'FileVersion' $FileVersion
+        Update-Property $ProjectXml $PropertyGroupElement 'PackageReleaseNotes' $PackageReleaseNotes
+
+        $ProjectXml.Save($Path)
+    } else {
+        Write-Warning "Project file format not supported. Skipping $Path"
+    }
+
+    # Return the input Path to enable pilelining.
+	return $Path
+}
+
+function Update-Property
+{
+    [CmdletBinding()]
+    param (
+        [Xml.XmlDocument] $XmlDocument,
+        [Xml.XmlElement] $ParentElement,
+        [string] $PropertyName,
+        [string] $PropertyValue
+    )
+
+    if (-not [string]::IsNullOrEmpty($PropertyValue)) {
+        Write-Verbose "  Setting property $PropertyName to $PropertyValue"
+        $PropertyElement = $ParentElement.SelectSingleNode($PropertyName)
+        if (-not $PropertyElement) {
+            $PropertyElement = $XmlDocument.CreateElement($PropertyName)
+            $Null = $ParentElement.AppendChild($PropertyElement)
+        }
+        $PropertyElement.InnerText = $PropertyValue
+    }
+}

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,7 @@
+# 0.5
+
+- New `Update-ProjectProperties` cmdlet that can be used to set various properties of a C# project file, such as Version, AssemblyVersion, FileVersion and PackageReleaseNotes. This provides an alternative to `Update-AssemblyVersion` as we progressively move away from using `AssemblyInfo.cs` files for project properties.
+
 # 0.4
 
 - `Invoke-SigningService` will now accept a NuGet package. The NuGet package is not directly signed itself. Instead, it is unpacked to a temporary folder, all the assembly dlls in the `lib` sub-folder are signed by the signing service, and then the NuGet package is reassembled. 

--- a/Tests/Update-ProjectProperties.Tests.ps1
+++ b/Tests/Update-ProjectProperties.Tests.ps1
@@ -1,0 +1,149 @@
+﻿#requires -Version 2 -Modules Pester
+
+
+Describe 'Update-AssemblyVersion' {
+
+    $XmlPath = "$([IO.Path]::GetTempPath())$([guid]::NewGuid()).csproj"
+    
+    Context 'given an empty project file' {
+        $Xml = [xml] @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+'@
+
+        It 'should have a <Version/> element when the Version parameter is specified' {
+            $Xml.Save($XmlPath)
+            Update-ProjectProperties -Path $XmlPath -Version '1.2.3.4-prerelease'
+            [IO.File]::ReadAllText($XmlPath) | Should Be @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>1.2.3.4-prerelease</Version>
+  </PropertyGroup>
+</Project>
+'@
+        }
+
+        It 'should have an <AssemblyVersion/> element when the AssemblyVersion parameter is specified' {
+            $Xml.Save($XmlPath)
+            Update-ProjectProperties -Path $XmlPath -AssemblyVersion '1.2.3.4'
+            [IO.File]::ReadAllText($XmlPath) | Should Be @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyVersion>1.2.3.4</AssemblyVersion>
+  </PropertyGroup>
+</Project>
+'@
+        }
+
+        It 'should have a <FileVersion/> element when the FileVersion parameter is specified' {
+            $Xml.Save($XmlPath)
+            Update-ProjectProperties -Path $XmlPath -FileVersion '1.2.3.4'
+            [IO.File]::ReadAllText($XmlPath) | Should Be @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <FileVersion>1.2.3.4</FileVersion>
+  </PropertyGroup>
+</Project>
+'@
+        }
+
+        It 'should have a <PackageReleaseNotes/> element when the PackageReleaseNotes parameter is specified' {
+            $Xml.Save($XmlPath)
+            Update-ProjectProperties -Path $XmlPath -PackageReleaseNotes 'RELEASE_NOTES'
+            [IO.File]::ReadAllText($XmlPath) | Should Be @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageReleaseNotes>RELEASE_NOTES</PackageReleaseNotes>
+  </PropertyGroup>
+</Project>
+'@
+        }
+    }
+
+    Context 'given a project file with existing properties' {
+        $Xml = [xml] @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>0.0.0.0</Version>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+    <FileVersion>0.0.0.0</FileVersion>
+    <PackageReleaseNotes>original-release-notes</PackageReleaseNotes>
+  </PropertyGroup>
+</Project>
+'@
+
+        It 'should have an updated <Version/> element when the Version parameter is specified' {
+            $Xml.Save($XmlPath)
+            Update-ProjectProperties -Path $XmlPath -Version '1.2.3.4-prerelease'
+            [IO.File]::ReadAllText($XmlPath) | Should Be @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>1.2.3.4-prerelease</Version>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+    <FileVersion>0.0.0.0</FileVersion>
+    <PackageReleaseNotes>original-release-notes</PackageReleaseNotes>
+  </PropertyGroup>
+</Project>
+'@
+        }
+
+        It 'should have an updated <AssemblyVersion/> element when the AssemblyVersion parameter is specified' {
+            $Xml.Save($XmlPath)
+            Update-ProjectProperties -Path $XmlPath -AssemblyVersion '1.2.3.4'
+            [IO.File]::ReadAllText($XmlPath) | Should Be @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>0.0.0.0</Version>
+    <AssemblyVersion>1.2.3.4</AssemblyVersion>
+    <FileVersion>0.0.0.0</FileVersion>
+    <PackageReleaseNotes>original-release-notes</PackageReleaseNotes>
+  </PropertyGroup>
+</Project>
+'@
+        }
+
+        It 'should have an updated <FileVersion/> element when the FileVersion parameter is specified' {
+            $Xml.Save($XmlPath)
+            Update-ProjectProperties -Path $XmlPath -FileVersion '1.2.3.4'
+            [IO.File]::ReadAllText($XmlPath) | Should Be @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>0.0.0.0</Version>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+    <FileVersion>1.2.3.4</FileVersion>
+    <PackageReleaseNotes>original-release-notes</PackageReleaseNotes>
+  </PropertyGroup>
+</Project>
+'@
+        }
+
+        It 'should have an updated <PackageReleaseNotes/> element when the PackageReleaseNotes parameter is specified' {
+            $Xml.Save($XmlPath)
+            Update-ProjectProperties -Path $XmlPath -PackageReleaseNotes 'RELEASE_NOTES'
+            [IO.File]::ReadAllText($XmlPath) | Should Be @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>0.0.0.0</Version>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+    <FileVersion>0.0.0.0</FileVersion>
+    <PackageReleaseNotes>RELEASE_NOTES</PackageReleaseNotes>
+  </PropertyGroup>
+</Project>
+'@
+        }
+    }
+
+    Remove-Item $XmlPath
+}


### PR DESCRIPTION
Adds a new `Update-ProjectProperties` cmdlet, that can be used to insert or update the `Version`, `AssemblyVersion`, `FileVersion` and `PackageReleaseNotes` properties within a VS2017-style project file. This is to complement `Update-AssemblyVersion` cmdlet, which does a similar job for `AssemblyInfo.cs` files.

For example, given the following project file:

```xml
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <TargetFramework>netstandard2.0</TargetFramework>
  </PropertyGroup>
   ...etc...
</Project>
```

If you invoke the following:

```powershell
Update-ProjectProperties `
    -Version '1.2.3.4-SomeBranch' `
    -AssemblyVersion '1.0.0.0' `
    -FileVersion '1.2.3.4' `
    -PackageReleaseNotes 'RELEASE-NOTES'
```

The project file's contents will be modified as follows:

```xml
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <TargetFramework>netstandard2.0</TargetFramework>
    <Version>1.2.3.4-SomeBranch</Version>
    <AssemblyVersion>1.0.0.0</AssemblyVersion>
    <FileVersion>1.2.3.4</FileVersion>
    <PackageReleaseNotes>RELEASE-NOTES</PackageReleaseNotes>
  </PropertyGroup>
   ...etc...
</Project>
```
