### PR TITLE
Send dotnet output to verbose stream

### DIFF
--- a/Public/Update-RedgateNugetPackages.ps1
+++ b/Public/Update-RedgateNugetPackages.ps1
@@ -217,7 +217,8 @@ function UpdatePackageReferences([string]$RootDir, [string[]]$IncludedPackages, 
                                 $updatedPackages += @("$packageName ($oldVersion -> $newVersion)")
                             }
                         }
-                    } | Write-Host
+                        $_
+                    } | Write-Verbose
                 }
             } finally {
                 Pop-Location


### PR DESCRIPTION
Fix an issue where dotnet output wasn't being printed. Also move it to to verbose stream.