### PR TITLE
Add switch to Update-NuspecDependenciesVersions to not use version ranges

### DIFF
--- a/Private/Nuget/Get-DependencyVersionRange.ps1
+++ b/Private/Nuget/Get-DependencyVersionRange.ps1
@@ -14,7 +14,8 @@ function Get-DependencyVersionRange
     param (
         [Parameter(Mandatory = $True, Position = 0, ValueFromPipeLine = $True)]
         [ValidateNotNullOrEmpty()]
-        [string] $Version
+        [string] $Version,
+        [switch] $SpecificVersion
     )
 
     if($Version.Contains('-'))
@@ -28,7 +29,7 @@ function Get-DependencyVersionRange
     }
 
     $versionParts = $currentVersion.Split(".")
-    if ($versionParts.Length -eq 3) #http://wiki/Semantic_Versioning
+    if ($versionParts.Length -eq 3 -And -Not $SpecificVersion) #http://wiki/Semantic_Versioning
     {
         $nextMajorVersion = [int] $versionParts[0] + 1
         $nextMajorVersionString = "$nextMajorVersion.0.0$branchSuffix"

--- a/Private/Nuget/Get-DependencyVersionRange.ps1
+++ b/Private/Nuget/Get-DependencyVersionRange.ps1
@@ -4,6 +4,8 @@
 .DESCRIPTION
   Takes a version of the form a.b.c[.d][-branchName], returns the version range to set in the nuspec
   [a.b.c[.d][-branchName], a+1.0.0)
+.PARAMETER SpecificVersion
+  A switch parameter that will enforce the use of a specific version rather than a range of versions, even if the version number passed in is semantically versioned. This can be used to prevent run-time assembly loading problems, for instance when several applications are running within the same application domain (i.e. SSMS plugins). 
 .EXAMPLE
   Get-DependencyVersionRange
 #>

--- a/Private/Nuget/Get-DependencyVersionRange.ps1
+++ b/Private/Nuget/Get-DependencyVersionRange.ps1
@@ -29,7 +29,7 @@ function Get-DependencyVersionRange
     }
 
     $versionParts = $currentVersion.Split(".")
-    if ($versionParts.Length -eq 3 -And -Not $SpecificVersion) #http://wiki/Semantic_Versioning
+    if ($versionParts.Length -eq 3 -And -Not $SpecificVersion) #https://semver.org/
     {
         $nextMajorVersion = [int] $versionParts[0] + 1
         $nextMajorVersionString = "$nextMajorVersion.0.0$branchSuffix"

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,7 @@
 # 0.5
 
 - New `Update-ProjectProperties` cmdlet that can be used to set various properties of a C# project file, such as Version, AssemblyVersion, FileVersion and PackageReleaseNotes. This provides an alternative to `Update-AssemblyVersion` as we progressively move away from using `AssemblyInfo.cs` files for project properties.
+- `Update-NuspecDependenciesVersions` now accepts the `-SpecificVersions` switch. Using the switch will use a specific version rather than a range for dependencies with three-part version numbers.
 
 # 0.4
 

--- a/Tests/Nuget/Get-DependencyVersionRange.Tests.ps1
+++ b/Tests/Nuget/Get-DependencyVersionRange.Tests.ps1
@@ -33,4 +33,8 @@ Describe 'Get-DependencyVersionRange' {
     It 'should handle a 3 part version with suffix where the suffix contains a dash' {
         Get-DependencyVersionRange '1.2.3-suffix-b' -verbose | Should Be '[1.2.3-suffix-b, 2.0.0-suffix-b)'
     }
+    
+    It 'should handle a 3 part version when specificversion specified' {
+        Get-DependencyVersionRange '1.2.3' -SpecificVersion | Should Be '[1.2.3]'
+    }
 }


### PR DESCRIPTION
With semantic versioning, we generate a range of values when we update a nuspec file. For example, `[1.2.3, 2.0.0)`. This is how strict semantic versioning works.

[Our policy](https://info.red-gate.com/eng/development-policies/libraries/versioning-assemblies) is not a strict interpretation of semantic versioning and as such we sometimes want to enforce a specific version rather than a range (i.e. SSMS plugins and apps with shared components running within a single appdomain). This switch will not change the current behaviour but will give us an opportunity to force specific versions if we wish.