### PR TITLE
Add net-4.7 as a supported framework version.

### DIFF
--- a/Public/Invoke-NUnitForAssembly.ps1
+++ b/Public/Invoke-NUnitForAssembly.ps1
@@ -27,7 +27,7 @@ function Invoke-NUnitForAssembly {
     # Whether to use nunit x86 or nunit x64 (default)
     [switch] $x86,
     # If specified, Framework version to be used for tests. (pass /framework=XX to nunit-console)
-    [ValidateSet($null, 'net-1.1', 'net-2.0', 'net-3.5', 'net-4.0', 'net-4.5', 'net-4.6')]
+    [ValidateSet($null, 'net-1.1', 'net-2.0', 'net-3.5', 'net-4.0', 'net-4.5', 'net-4.6', 'net-4.7')]
     [string] $FrameworkVersion,
     # A list of excluded test categories
     [string[]] $ExcludedCategories = @(),


### PR DESCRIPTION
Updates `Invoke-NUnitForAssembly` to add `net-4.7` as a supported runtime.