### PR TITLE
Don't trim release notes lines

### DIFF
--- a/Public/Select-ReleaseNotes.ps1
+++ b/Public/Select-ReleaseNotes.ps1
@@ -197,7 +197,7 @@ function Select-ReleaseNotes {
         $Lines = Get-Content $ReleaseNotesPath
     } elseif ($ReleaseNotes) {
         # Makes testing easier
-        $Lines = ($ReleaseNotes -Replace "'r").Split("`n")
+        $Lines = ($ReleaseNotes -Replace "`r").Split("`n")
     } else {
         # Shouldn't happen due to ParameterSetName usage above
         throw 'No $ReleaseNotesPath or $ReleaseNotes specified'

--- a/Public/Select-ReleaseNotes.ps1
+++ b/Public/Select-ReleaseNotes.ps1
@@ -203,10 +203,10 @@ function Select-ReleaseNotes {
         throw 'No $ReleaseNotesPath or $ReleaseNotes specified'
     }
 
-    $VersionRegex = '^#+\s*(?<version>[0-9]+\.[0-9]+(\.[0-9]+)?(\.[0-9]+)?)(\s*-\s*(?<date>.*))?\s*$'
-    $HeaderRegex = '^#+\s*(?<header>.+):?\s*$'
-    $DateRegex = '^#+\s*.*(?<date>\d\d\d\d.\d\d.\d\d)'
-    $StraplineStartRegex = '^#+\s*Strapline\s*$'
+    $VersionRegex = '^\s*#+\s*(?<version>[0-9]+\.[0-9]+(\.[0-9]+)?(\.[0-9]+)?)(\s*-\s*(?<date>.*))?\s*$'
+    $HeaderRegex = '^\s*#+\s*(?<header>.+):?\s*$'
+    $DateRegex = '^\s*#+\s*.*(?<date>\d\d\d\d.\d\d.\d\d)'
+    $StraplineStartRegex = '^\s*#+\s*Strapline\s*$'
     $StraplineRegex = '^\s*(?<priority>[0-9]+)\s*-\s*(?<feature>.*)\s*$'
 
     $Accumulator = @{}
@@ -214,7 +214,6 @@ function Select-ReleaseNotes {
     $Release = $nul
     
     foreach($Line in $Lines) {
-        $Line = $Line.Trim()
         $VersionMatch = [regex]::Match($Line, $VersionRegex)
         if ($VersionMatch.Success) {
             # If a $Release already was being filled in - clean it up and return it

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,7 @@
 # 0.5
 
 - New `Update-ProjectProperties` cmdlet that can be used to set various properties of a C# project file, such as Version, AssemblyVersion, FileVersion and PackageReleaseNotes. This provides an alternative to `Update-AssemblyVersion` as we progressively move away from using `AssemblyInfo.cs` files for project properties.
+- `Select-ReleaseNotes` now preserves whitespace.
 
 # 0.4
 

--- a/Tests/Select-ReleaseNotes.Tests.ps1
+++ b/Tests/Select-ReleaseNotes.Tests.ps1
@@ -314,3 +314,27 @@ Text
         }
     }
 }
+
+# Indentation in block content is preserved
+InModuleScope RedGate.Build {
+    Context 'Indentation is preserved' {
+        $v = Select-ReleaseNotes -ProductName "Test" -Latest -ReleaseNotes @"
+## 3.1.1
+### Features
+* A feature
+
+  With indented content, whose whitespace
+  ought to be preserved
+
+* Another feature
+"@
+        $v.Blocks[0].Value | Should Be @"
+* A feature
+
+  With indented content, whose whitespace
+  ought to be preserved
+
+* Another feature
+"@
+    }
+}


### PR DESCRIPTION
Leading whitespace can be significant in markdown (it's an indent). Instead of trimming every line in Select-ReleaseNote, modify the relevant Regexs to allow leading whitespace.

I need this so that our auto-uploading release notes in DLMAutomation can have indented sections.