### PR TITLE
Remove validation set from -FrameworkVersion parameters of the NUnit cmdlets

### DIFF
--- a/Public/Invoke-NUnit3ForAssembly.ps1
+++ b/Public/Invoke-NUnit3ForAssembly.ps1
@@ -25,9 +25,8 @@ function Invoke-NUnit3ForAssembly {
     [string] $NUnitVersion = '3.0.0',
     # If specified, pass --x86 to nunit3-console
     [switch] $x86,
-    # If specified, Framework version to be used for tests. (pass --framework=XX to nunit3-console)
-    [ValidateSet($null, 'mono', 'mono-4.0', 'net-2.0', 'net-3.5', 'net-4.0')]
-    [string] $FrameworkVersion,
+    # If specified, the framework version to be used for tests. (pass --framework=XX to nunit3-console). e.g. 'net-4.6', 'net-4.7'
+    [string] $FrameworkVersion = $null,
     # NUnit3 Test selection EXPRESSION indicating what tests will be run
     # example: "method =~ /DataTest*/ && cat = Slow"
     [string] $Where,

--- a/Public/Invoke-NUnitForAssembly.ps1
+++ b/Public/Invoke-NUnitForAssembly.ps1
@@ -26,9 +26,8 @@ function Invoke-NUnitForAssembly {
     [string] $NUnitVersion = $DefaultNUnitVersion,
     # Whether to use nunit x86 or nunit x64 (default)
     [switch] $x86,
-    # If specified, Framework version to be used for tests. (pass /framework=XX to nunit-console)
-    [ValidateSet($null, 'net-1.1', 'net-2.0', 'net-3.5', 'net-4.0', 'net-4.5', 'net-4.6', 'net-4.7')]
-    [string] $FrameworkVersion,
+    # If specified, the framework version to be used for tests. (pass /framework=XX to nunit-console). e.g. 'net-4.6', 'net-4.7'
+    [string] $FrameworkVersion = $null,
     # A list of excluded test categories
     [string[]] $ExcludedCategories = @(),
     # A list of incuded test categories


### PR DESCRIPTION
This removes the validation set from the `-FrameworkVersion` parameters of both `Invoke-NUnitForAssembly` and `Invoke-NUnit3ForAssembly`

The caller gets to specify the version of NUnit they want to use. Different versions of NUnit support different frameworks, and are more than happy to complain if an unsupported framework version is specified. There's no need to apply our own validation, and it's actually got in the way a number of times recently.