### PR TITLE
Force our alias declarations

### DIFF
--- a/Public/Expand-ZipArchive.ps1
+++ b/Public/Expand-ZipArchive.ps1
@@ -31,4 +31,4 @@ function Expand-ZipArchive {
   }
 }
 
-New-Alias Unzip-Files Expand-ZipArchive
+New-Alias Unzip-Files Expand-ZipArchive -Force

--- a/Public/New-ZipArchive.ps1
+++ b/Public/New-ZipArchive.ps1
@@ -72,4 +72,4 @@ function New-ZipArchive {
     }
 }
 
-New-Alias Zip-Files New-ZipArchive
+New-Alias Zip-Files New-ZipArchive -Force


### PR DESCRIPTION
We have two alias declarations, neither of which are forced (use the `-Force`) switch, which makes reimporting the RedGate.Build module fail. Forcing those alias declarations helps to make importing this module idempotent.