### PR TITLE
Set the working directory for a test run

### DIFF
--- a/Public/Invoke-DotCoverForExecutable.ps1
+++ b/Public/Invoke-DotCoverForExecutable.ps1
@@ -73,7 +73,7 @@ function Invoke-DotCoverForExecutable {
     $DotCoverArguments += "/TargetArguments=$EscapedTargetArguments"
   }
 
-  if (![string]::IsNullOrWhiteSpace($TargetWorkingDirectory)) {
+  if ($TargetWorkingDirectory) {
     $DotCoverArguments += "/TargetWorkingDir=`"$TargetWorkingDirectory`""
   }
 

--- a/Public/Invoke-DotCoverForExecutable.ps1
+++ b/Public/Invoke-DotCoverForExecutable.ps1
@@ -17,6 +17,8 @@
   Attribute coverage filters for dotCover, to indicate what should and should not be covered.
 .PARAMETER ProcessFilters
   Process coverage filters for dotCover, to indicate what should and should not be covered. Requires Dot Cover 2016.2 or later.
+.PARAMETER TargetWorkingDirectory
+  The working directory of the target executable.
 #>
 function Invoke-DotCoverForExecutable {
   [CmdletBinding()]
@@ -41,7 +43,10 @@ function Invoke-DotCoverForExecutable {
     [string] $AttributeFilters = '',
 
     [Parameter(Mandatory = $False)]
-    [string] $ProcessFilters = ''
+    [string] $ProcessFilters = '',
+
+    [Parameter(Mandatory = $False)]
+    [string] $TargetWorkingDirectory
   )
 
   $DotCoverArguments = @(
@@ -66,6 +71,10 @@ function Invoke-DotCoverForExecutable {
   if ($TargetArguments) {
     $EscapedTargetArguments = ConvertTo-ShellEscaped $TargetArguments
     $DotCoverArguments += "/TargetArguments=$EscapedTargetArguments"
+  }
+
+  if (![string]::IsNullOrWhiteSpace($TargetWorkingDirectory)) {
+    $DotCoverArguments += "/TargetWorkingDir=$TargetWorkingDirectory"
   }
 
   $DotCoverPath = Get-DotCoverExePath -DotCoverVersion $DotCoverVersion

--- a/Public/Invoke-DotCoverForExecutable.ps1
+++ b/Public/Invoke-DotCoverForExecutable.ps1
@@ -74,7 +74,7 @@ function Invoke-DotCoverForExecutable {
   }
 
   if (![string]::IsNullOrWhiteSpace($TargetWorkingDirectory)) {
-    $DotCoverArguments += "/TargetWorkingDir=$TargetWorkingDirectory"
+    $DotCoverArguments += "/TargetWorkingDir=`"$TargetWorkingDirectory`""
   }
 
   $DotCoverPath = Get-DotCoverExePath -DotCoverVersion $DotCoverVersion

--- a/Public/Invoke-NUnit3ForAssembly.ps1
+++ b/Public/Invoke-NUnit3ForAssembly.ps1
@@ -43,7 +43,9 @@ function Invoke-NUnit3ForAssembly {
     # The dotcover filters passed to dotcover.exe
     [string] $DotCoverAttributeFilters = '',
     # The dotcover process filters passed to dotcover.exe. Requires dotcover version 2016.2 or later
-    [string] $DotCoverProcessFilters = ''
+    [string] $DotCoverProcessFilters = '',
+    # The working directory of the test process
+    [string] $TargetWorkingDirectory
   )
 
   Get-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState -Name 'VerbosePreference'
@@ -76,14 +78,18 @@ function Invoke-NUnit3ForAssembly {
         -DotCoverVersion $DotCoverVersion `
         -Filters $DotCoverFilters `
         -AttributeFilters $DotCoverAttributeFilters `
-        -ProcessFilters $DotCoverProcessFilters
+        -ProcessFilters $DotCoverProcessFilters `
+        -TargetWorkingDirectory $TargetWorkingDirectory
 
     } else {
+
+      if (![string]::IsNullOrWhiteSpace($TargetWorkingDirectory)) {
+        Push-Location $TargetWorkingDirectory
+      }
 
       Execute-Command {
         & $NunitExecutable $NunitArguments
       }
-
     }
 
   } finally {
@@ -92,6 +98,10 @@ function Invoke-NUnit3ForAssembly {
         -AssemblyPath $AssemblyPath `
         -TestResultFilenamePattern $TestResultFilenamePattern `
         -ImportResultsToCIServer (!$isTeamcity) # Do not import results to Teamcity since NUnit 3 uses service messages to integrate with Teamcity on its own.
+      
+        if (![string]::IsNullOrWhiteSpace($TargetWorkingDirectory)) {
+        Pop-Location
+      }
   }
 
 }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,7 @@
 # 0.6
 
 - `Update-NuspecDependenciesVersions` now accepts the `-SpecificVersions` switch. Using the switch will use a specific version rather than a range for dependencies with three-part version numbers.
+- `Invoke-NUnit3ForAssembly` and `Invoke-DotCoverForExecutable` now accept the optional `-TargetWorkingDirectory` parameter to specify the working directory for the tests to run in
 
 # 0.5
 

--- a/Tests/Nunit/3/Invoke-NUnit3ForAssembly.Tests.ps1
+++ b/Tests/Nunit/3/Invoke-NUnit3ForAssembly.Tests.ps1
@@ -11,13 +11,14 @@ Describe 'Invoke-NUnit3ForAssembly' {
     }
     
     Context 'Nunit 3.0.0' {
+        Mock -ModuleName RedGate.Build Invoke-DotCoverForExecutable { }
+
         It 'should pass where clause as an argument' {
             $ExpectedWhereClause = 'cat == TestWhereClause';
-            Mock -ModuleName RedGate.Build Invoke-DotCoverForExecutable { }
             
             Invoke-NUnit3ForAssembly -Assembly 'build.ps1' -NUnitVersion '3.0.0' -EnableCodeCoverage $true -Where $ExpectedWhereClause
             
-            Assert-MockCalled Invoke-DotCoverForExecutable -ModuleName RedGate.Build -Times 1 -ParameterFilter {$TargetArguments -like "*$ExpectedWhereClause*"}
+            Assert-MockCalled Invoke-DotCoverForExecutable -ModuleName RedGate.Build -Times 1 -ParameterFilter {$TargetArguments -like "*$ExpectedWhereClause*"} -Scope It
         }
     }
 }

--- a/Tests/Nunit/3/Invoke-NUnit3ForAssembly.Tests.ps1
+++ b/Tests/Nunit/3/Invoke-NUnit3ForAssembly.Tests.ps1
@@ -12,6 +12,9 @@ Describe 'Invoke-NUnit3ForAssembly' {
     
     Context 'Nunit 3.0.0' {
         Mock -ModuleName RedGate.Build Invoke-DotCoverForExecutable { }
+        Mock -ModuleName RedGate.Build Push-Location { }
+        Mock -ModuleName RedGate.Build Pop-Location { }
+        Mock -ModuleName RedGate.Build Execute-Command { }
 
         It 'should pass where clause as an argument' {
             $ExpectedWhereClause = 'cat == TestWhereClause';
@@ -19,6 +22,30 @@ Describe 'Invoke-NUnit3ForAssembly' {
             Invoke-NUnit3ForAssembly -Assembly 'build.ps1' -NUnitVersion '3.0.0' -EnableCodeCoverage $true -Where $ExpectedWhereClause
             
             Assert-MockCalled Invoke-DotCoverForExecutable -ModuleName RedGate.Build -Times 1 -ParameterFilter {$TargetArguments -like "*$ExpectedWhereClause*"} -Scope It
+        }
+
+        It 'should pass working directory as an argument' {
+            $ExpectedWorkingDirectory = 'd:\working\directory\'
+
+            Invoke-NUnit3ForAssembly -Assembly 'build.ps1' -NUnitVersion '3.0.0' -EnableCodeCoverage $true -TargetWorkingDirectory $ExpectedWorkingDirectory
+
+            Assert-MockCalled Invoke-DotCoverForExecutable -ModuleName RedGate.Build -Times 1 -ParameterFilter {$TargetWorkingDirectory -eq $ExpectedWorkingDirectory} -Scope It
+        }
+
+        It 'should set working directory when no code coverage' {
+            $ExpectedWorkingDirectory = 'd:\working\directory\'
+
+            Invoke-NUnit3ForAssembly -Assembly 'build.ps1' -NUnitVersion '3.0.0' -EnableCodeCoverage $false -TargetWorkingDirectory $ExpectedWorkingDirectory
+
+            Assert-MockCalled Push-Location -ModuleName RedGate.Build -Times 1 -ParameterFilter {$Path -eq $ExpectedWorkingDirectory} -Scope It
+            Assert-MockCalled Pop-Location -ModuleName RedGate.Build -Times 1 -Scope It
+        }
+
+        It 'should not set working directory when parameter not passed' {
+            Invoke-NUnit3ForAssembly -Assembly 'build.ps1' -NUnitVersion '3.0.0' -EnableCodeCoverage $false
+
+            Assert-MockCalled Push-Location -ModuleName RedGate.Build -Exactly 0 -Scope It
+            Assert-MockCalled Pop-Location -ModuleName RedGate.Build -Exactly 0 -Scope It
         }
     }
 }


### PR DESCRIPTION
This adds the optional `-TargetWorkingDirectory` parameter to `Invoke-NUnit3ForAssembly` and `Invoke-DotCoverForExecutable` so that you can specify the working directory for the test run.

I've added three new unit tests to check that `Invoke-NUnit3ForAssembly` calls things in the expected way.