### PR TITLE
Update Remove-IgnoredTests to support NUnit 3 results format

### DIFF
--- a/Public/Remove-IgnoredTests.ps1
+++ b/Public/Remove-IgnoredTests.ps1
@@ -37,7 +37,7 @@ function Remove-IgnoredTests {
   Write-Verbose "Loading test results from $TestResultsPath"
   $xml = [xml](Get-Content $TestResultsPath)
 
-  $ignoredTests = $xml | Select-Xml -XPath '//test-suite[@result="Ignored"]'
+  $ignoredTests = $xml | Select-Xml -XPath '//test-suite[@result="Ignored" or @label="Ignored"]'
 
   foreach($test in $ignoredTests) {
     foreach( $reason in @($ReasonsIgnored)  ) {

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,7 @@
 
 - `Update-NuspecDependenciesVersions` now accepts the `-SpecificVersions` switch. Using the switch will use a specific version rather than a range for dependencies with three-part version numbers.
 - `Invoke-NUnit3ForAssembly` and `Invoke-DotCoverForExecutable` now accept the optional `-TargetWorkingDirectory` parameter to specify the working directory for the tests to run in
+- `Remove-IgnoredTests` now supports the NUnit 3 results xml format
 
 # 0.5
 


### PR DESCRIPTION
This PR updates the xpath to support NUnit 3 runs. The format of the XML file changed very slightly from `result="Ignored"` to `result="Skipped" label="Ignored"`.