### PR TITLE
Remove dead argument

### DIFF
--- a/Private/NUnit/3/Build-NUnit3CommandLineArguments.ps1
+++ b/Private/NUnit/3/Build-NUnit3CommandLineArguments.ps1
@@ -13,8 +13,7 @@ function Build-NUnit3CommandLineArguments {
         "--result=`"$AssemblyPath.$TestResultFilenamePattern.xml`"",
         "--noheader",
         "--labels=On",
-        "--out=`"$AssemblyPath.$TestResultFilenamePattern.TestOutput.txt`"",
-        "--err=`"$AssemblyPath.$TestResultFilenamePattern.TestError.txt`""
+        "--out=`"$AssemblyPath.$TestResultFilenamePattern.TestOutput.txt`""
 
     if($x86) {
         $params += "--x86"

--- a/Tests/Nunit/3/Build-NUnit3CommandLineArguments.Tests.ps1
+++ b/Tests/Nunit/3/Build-NUnit3CommandLineArguments.Tests.ps1
@@ -7,7 +7,7 @@ $FullPathToModuleRoot = Resolve-Path $PSScriptRoot\..\..\..
 Describe 'Build-NUnit3CommandLineArguments' {
 
     function Nunit3Parameters($assembly, $TestResult = 'TestResult') {
-        "$assembly --result=`"$assembly.$TestResult.xml`" --noheader --labels=On --out=`"$assembly.$TestResult.TestOutput.txt`" --err=`"$assembly.$TestResult.TestError.txt`""
+        "$assembly --result=`"$assembly.$TestResult.xml`" --noheader --labels=On --out=`"$assembly.$TestResult.TestOutput.txt`"
     }
 
     Context 'With minimum arguments' {

--- a/Tests/Nunit/3/Build-NUnit3CommandLineArguments.Tests.ps1
+++ b/Tests/Nunit/3/Build-NUnit3CommandLineArguments.Tests.ps1
@@ -7,7 +7,7 @@ $FullPathToModuleRoot = Resolve-Path $PSScriptRoot\..\..\..
 Describe 'Build-NUnit3CommandLineArguments' {
 
     function Nunit3Parameters($assembly, $TestResult = 'TestResult') {
-        "$assembly --result=`"$assembly.$TestResult.xml`" --noheader --labels=On --out=`"$assembly.$TestResult.TestOutput.txt`"
+        "$assembly --result=`"$assembly.$TestResult.xml`" --noheader --labels=On --out=`"$assembly.$TestResult.TestOutput.txt`""
     }
 
     Context 'With minimum arguments' {


### PR DESCRIPTION
The `--err` argument has apparently not worked since nUnit Runner  2.9, and was removed altogether in 3.9.0, so we should remove it.