### PR TITLE
Use an xslt transform to remove ignored tests

### DIFF
--- a/Private/Utils.ps1
+++ b/Private/Utils.ps1
@@ -51,3 +51,27 @@ function Test-FileUnlocked {
     return $false
   }
 }
+
+function Wait-FileUnlocked {
+  [CmdletBinding()]
+  param(
+    # The path of the file that is being waited on
+    [Parameter(Mandatory=$true)]
+    [string] $Path,
+    # The timeout value in seconds
+    [Parameter(Mandatory=$false)]
+    [int] $Timeout = 300
+  )
+
+  $totalSleep = 0
+  while (-not (Test-FileUnlocked -Path $Path))
+  {
+    if ($totalSleep -ge $Timeout)
+    {
+      throw [System.TimeoutException] "File $Path has been locked for more than $Timeout seconds."
+    }
+    Write-Verbose "File $Path locked. Sleeping for 10 seconds."
+    $totalSleep += 10
+    Start-Sleep -s 10
+  }
+}

--- a/Private/Utils.ps1
+++ b/Private/Utils.ps1
@@ -31,3 +31,23 @@ Executing: $ScriptBlock
 
   }
 }
+
+function Test-FileUnlocked {
+  [CmdletBinding()]
+  param(
+    # The path of the file to check the lock status of
+    [Parameter(Mandatory=$true)]
+    [string] $Path
+  )
+
+  try {
+    $Path = Resolve-Path $Path
+    $stream = [System.IO.File]::Open($Path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+    $stream.Close()
+    $stream.Dispose()
+    return $true
+  }
+  catch {
+    return $false
+  }
+}

--- a/Public/Remove-IgnoredTests.ps1
+++ b/Public/Remove-IgnoredTests.ps1
@@ -33,7 +33,8 @@ function Remove-IgnoredTests {
     $DestinationFilePath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($DestinationFilePath)
   }
 
-  $whereClause = "//test-suite[(@result='Ignored' or @label='Ignored') and (" + (($ReasonsIgnored | ForEach-Object { "reason/message='$_'" }) -join " or ") + ")]"
+  $reasonsIgnoredString = ($ReasonsIgnored | ForEach-Object { "reason/message='$_'" }) -join " or "
+  $whereClause = "//test-suite[(@result='Ignored' or @label='Ignored') and (" + $reasonsIgnoredString + ")]"
 
   $stringBuilder = [System.Text.StringBuilder]::new()
   $stringBuilder.AppendLine("<xsl:stylesheet version=`"1.0`" xmlns:xsl=`"http://www.w3.org/1999/XSL/Transform`">") | Out-Null

--- a/Public/Remove-IgnoredTests.ps1
+++ b/Public/Remove-IgnoredTests.ps1
@@ -34,16 +34,16 @@ function Remove-IgnoredTests {
   }
 
   $reasonsIgnoredString = ($ReasonsIgnored | ForEach-Object { "reason/message='$_'" }) -join " or "
-  $whereClause = "//test-suite[(@result='Ignored' or @label='Ignored') and (" + $reasonsIgnoredString + ")]"
 
-  $stringBuilder = [System.Text.StringBuilder]::new()
-  $stringBuilder.AppendLine("<xsl:stylesheet version=`"1.0`" xmlns:xsl=`"http://www.w3.org/1999/XSL/Transform`">") | Out-Null
-  $stringBuilder.AppendLine("<xsl:template match=`"@* | node()`"><xsl:copy><xsl:apply-templates select=`"@* | node()`"/></xsl:copy></xsl:template>") | Out-Null
-  $stringBuilder.AppendLine("<xsl:template match=`"$whereClause`" />") | Out-Null
-  $stringBuilder.AppendLine("</xsl:stylesheet>") | Out-Null
- 
+  $xsl = @"
+  <xsl:stylesheet version=`"1.0`" xmlns:xsl=`"http://www.w3.org/1999/XSL/Transform`">
+  <xsl:template match=`"@* | node()`"><xsl:copy><xsl:apply-templates select=`"@* | node()`"/></xsl:copy></xsl:template>
+  <xsl:template match=`"//test-suite[(@result='Ignored' or @label='Ignored') and ($reasonsIgnoredString)`" />
+  </xsl:stylesheet>
+"@
+
   $compiledTransform = [System.Xml.Xsl.XslCompiledTransform]::new()
-  $stringReader = [System.IO.StringReader]::new($stringBuilder.ToString())
+  $stringReader = [System.IO.StringReader]::new($xsl)
   $xmlReader = [System.Xml.XmlTextReader]::new($stringReader)
   $compiledTransform.Load($xmlReader)
   $stringReader.Dispose()

--- a/Public/Remove-IgnoredTests.ps1
+++ b/Public/Remove-IgnoredTests.ps1
@@ -60,8 +60,8 @@ function Remove-IgnoredTests {
   $writer.Dispose()
 
   Wait-FileUnlocked -Path $TestResultsPath
-  Write-Host "Moving temporary file to the specified location"
+  Write-Verbose "Moving temporary file to the specified location"
   Move-Item -Path $tempFileName -Destination $DestinationFilePath -Force -Verbose
-  Write-Host "Removing the temporary directory"
+  Write-Verbose "Removing the temporary directory"
   Remove-Item -Path $tempDirectory -Recurse -Force -Verbose
 }

--- a/Public/Remove-IgnoredTests.ps1
+++ b/Public/Remove-IgnoredTests.ps1
@@ -59,18 +59,7 @@ function Remove-IgnoredTests {
   $reader.Dispose()
   $writer.Dispose()
 
-  $totalSleep = 0
-  while (-not (Test-FileUnlocked -Path $TestResultsPath))
-  {
-    if ($totalSleep -ge 300)
-    {
-      throw [System.TimeoutException] "File $testResultsPath has been locked for more than 5 minutes."
-    }
-    Write-Host "File $testResultsPath locked. Sleeping for 10 seconds."
-    $totalSleep += 10
-    Start-Sleep -s 10
-  }
-
+  Wait-FileUnlocked -Path $TestResultsPath
   Write-Host "Moving temporary file to the specified location"
   Move-Item -Path $tempFileName -Destination $DestinationFilePath -Force -Verbose
   Write-Host "Removing the temporary directory"

--- a/Public/Remove-IgnoredTests.ps1
+++ b/Public/Remove-IgnoredTests.ps1
@@ -58,8 +58,17 @@ function Remove-IgnoredTests {
   $reader.Dispose()
   $writer.Dispose()
 
-  Move-Item -Path $tempFileName -Destination $DestinationFilePath -Force
-  Remove-Item -Path $tempDirectory -Recurse -Force
+  if (Test-Path -Path $DestinationFilePath)
+  {
+    $destinationFileName = Split-Path -Path $DestinationFilePath -Leaf
+    Write-Host "Destination file already exists, renaming it to $destinationFileName.original"
+    Rename-Item -Path $DestinationFilePath "$destinationFileName.original" -Force -Verbose
+  }
+  
+  Write-Host "Moving temporary file to the specified location"
+  Move-Item -Path $tempFileName -Destination $DestinationFilePath -Force -Verbose
+  Write-Host "Removing the temporary directory"
+  Remove-Item -Path $tempDirectory -Recurse -Force -Verbose
 }
 
 function Process-TestSuite {

--- a/Public/Remove-IgnoredTests.ps1
+++ b/Public/Remove-IgnoredTests.ps1
@@ -64,19 +64,9 @@ function Remove-IgnoredTests {
     Write-Host "Destination file already exists, renaming it to $destinationFileName.original"
     Rename-Item -Path $DestinationFilePath "$destinationFileName.original" -Force -Verbose
   }
-  
+
   Write-Host "Moving temporary file to the specified location"
   Move-Item -Path $tempFileName -Destination $DestinationFilePath -Force -Verbose
   Write-Host "Removing the temporary directory"
   Remove-Item -Path $tempDirectory -Recurse -Force -Verbose
-}
-
-function Process-TestSuite {
-  [CmdletBinding()]
-  param(
-    # The path of the test results xml file to process
-    [Parameter(Mandatory=$true)]
-    [System.Xml.XmlReader] $XmlReader
-  )
-
 }

--- a/Public/Remove-IgnoredTests.ps1
+++ b/Public/Remove-IgnoredTests.ps1
@@ -17,7 +17,8 @@ function Remove-IgnoredTests {
 
     # A list of ignored reason messages.
     # Only tests with a ignored reason matching a string in this list will be removed
-    [string[]] $ReasonsIgnored = @(),
+    [Parameter(Mandatory=$true)]
+    [string[]] $ReasonsIgnored,
 
     # Use this parameter to save the updated xml to a different file
     [string] $DestinationFilePath

--- a/Public/Remove-IgnoredTests.ps1
+++ b/Public/Remove-IgnoredTests.ps1
@@ -58,11 +58,16 @@ function Remove-IgnoredTests {
   $reader.Dispose()
   $writer.Dispose()
 
-  if (Test-Path -Path $DestinationFilePath)
+  $totalSleep = 0
+  while (-not (Test-FileUnlocked -Path $TestResultsPath))
   {
-    $destinationFileName = Split-Path -Path $DestinationFilePath -Leaf
-    Write-Host "Destination file already exists, renaming it to $destinationFileName.original"
-    Rename-Item -Path $DestinationFilePath "$destinationFileName.original" -Force -Verbose
+    if ($totalSleep -ge 300)
+    {
+      throw [System.TimeoutException] "File $testResultsPath has been locked for more than 5 minutes."
+    }
+    Write-Host "File $testResultsPath locked. Sleeping for 10 seconds."
+    $totalSleep += 10
+    Start-Sleep -s 10
   }
 
   Write-Host "Moving temporary file to the specified location"

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,7 +2,7 @@
 
 - `Update-NuspecDependenciesVersions` now accepts the `-SpecificVersions` switch. Using the switch will use a specific version rather than a range for dependencies with three-part version numbers.
 - `Invoke-NUnit3ForAssembly` and `Invoke-DotCoverForExecutable` now accept the optional `-TargetWorkingDirectory` parameter to specify the working directory for the tests to run in
-- `Remove-IgnoredTests` now supports the NUnit 3 results xml format
+- `Remove-IgnoredTests` now supports the NUnit 3 results xml format and uses an xslt transform to perform the removal
 
 # 0.5
 


### PR DESCRIPTION
This PR uses an xslt transform to remove ignored tests. The advantage of this is that it uses streams and avoids loading the whole contents of the file into memory. This can prevent out of memory exceptions with large test runs.

Additionally, some result files were observed during TeamCity runs to still be open after the test run had allegedly finished. The method now waits for the lock on the file to be released before 