### PR TITLE
Workaround powershell 5.1.17763.1 throwing errors on 'git checkout -B' 

### DIFF
--- a/Public/GitHub/Push-GitChangesToBranch.ps1
+++ b/Public/GitHub/Push-GitChangesToBranch.ps1
@@ -49,7 +49,9 @@ Function Push-GitChangesToBranch
     git config --local user.name $CommitUsername
     git config --local user.email $CommitEmail
 
-    execute-command { & git checkout -B $BranchName }
+    # Redirect git's stderr to stdout then to Write-Host
+    # for powershell v5.1.17763.1 (Windows Server 2019) to stop throwing errors
+    execute-command { & git checkout -B $BranchName 2>&1 | Write-Host }
     execute-command { & git add --all }
     execute-command { & git commit -am $CommitMessage }
     execute-command { & git push -f $RemoteName $BranchName`:$BranchName }


### PR DESCRIPTION
Looks like powershell 5.1.17763.1 (Windows Server 2019) is throwing errors even though `git checkout -B` is successful. Suspect that is because `git checkout -B` prints its output on stderr... 😓😓 