### PR TITLE
Only include NUnit process when running code coverage

### DIFF
--- a/Public/Invoke-NUnit3ForAssembly.ps1
+++ b/Public/Invoke-NUnit3ForAssembly.ps1
@@ -43,7 +43,7 @@ function Invoke-NUnit3ForAssembly {
     # The dotcover filters passed to dotcover.exe
     [string] $DotCoverAttributeFilters = '',
     # The dotcover process filters passed to dotcover.exe. Requires dotcover version 2016.2 or later
-    [string] $DotCoverProcessFilters = '',
+    [string] $DotCoverProcessFilters = '+:nunit3-console.exe',
     # The working directory of the test process
     [string] $TargetWorkingDirectory
   )

--- a/Public/Invoke-NUnitForAssembly.ps1
+++ b/Public/Invoke-NUnitForAssembly.ps1
@@ -48,7 +48,7 @@ function Invoke-NUnitForAssembly {
     [string] $DotCoverProcessFilters = '+:nunit-console.exe;+:nunit-console-x86.exe',
     # If set, do not import test results automatically to Teamcity.
     # In this case it is the responsibility of the caller to call 'TeamCity-ImportNUnitReport "$AssemblyPath.$TestResultFilenamePattern.xml"'
-    [switch] $DotNotImportResultsToTeamcity
+    [switch] $DoNotImportResultsToTeamcity
   )
 
   Get-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState -Name 'VerbosePreference'
@@ -99,7 +99,7 @@ function Invoke-NUnitForAssembly {
       Publish-ResultsAndLogs `
         -AssemblyPath $AssemblyPath `
         -TestResultFilenamePattern $TestResultFilenamePattern `
-        -ImportResultsToCIServer (!$DotNotImportResultsToTeamcity.IsPresent)
+        -ImportResultsToCIServer (!$DoNotImportResultsToTeamcity.IsPresent)
   }
 
 }

--- a/Public/Invoke-NUnitForAssembly.ps1
+++ b/Public/Invoke-NUnitForAssembly.ps1
@@ -45,7 +45,7 @@ function Invoke-NUnitForAssembly {
     # The dotcover filters passed to dotcover.exe
     [string] $DotCoverAttributeFilters = '',
     # The dotcover process filters passed to dotcover.exe. Requires dotcover version 2016.2 or later
-    [string] $DotCoverProcessFilters = '',
+    [string] $DotCoverProcessFilters = '+:nunit-console.exe;+:nunit-console-x86.exe',
     # If set, do not import test results automatically to Teamcity.
     # In this case it is the responsibility of the caller to call 'TeamCity-ImportNUnitReport "$AssemblyPath.$TestResultFilenamePattern.xml"'
     [switch] $DotNotImportResultsToTeamcity

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,7 @@
 # 1.0
 
 - `Invoke-NUnitForAssembly` and `Invoke-NUnit3ForAssembly`, when run with code coverage enabled, by default only cover the NUnit process itself, any not any subprocesses. This can be overridden using the `-DotCoverProcessFilters` parameter.
+- `-DotNotImportResultsToTeamcity` has been renamed to `-DoNotImportResultsToTeamcity` (removing the extra t).
 
 # 0.6
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,7 @@
+# 1.0
+
+- `Invoke-NUnitForAssembly` and `Invoke-NUnit3ForAssembly`, when run with code coverage enabled, by default only cover the NUnit process itself, any not any subprocesses. This can be overridden using the `-DotCoverProcessFilters` parameter.
+
 # 0.6
 
 - `Update-NuspecDependenciesVersions` now accepts the `-SpecificVersions` switch. Using the switch will use a specific version rather than a range for dependencies with three-part version numbers.


### PR DESCRIPTION
Tests that use LocalDB result in dotCover doing code coverage of sqlservr.exe - and consequently waiting for the LocalDB instance to exit before the code coverage is finished! Which normally takes 5-10 mins. In most situations, you only actually want to cover what's run by the tests themselves, and not external processes, so this PR defaults the process filter parameters in `Invoke-NUnitForAssembly` and `Invoke-NUnit3ForAssembly` to only include the NUnit process itself.

As this is a potentially breaking change, I've bumped the version number to 1.0.

As I've bumped the version number to 1.0, I thought it made sense to include another breaking change, of fixing the typo `-DotNotImportResultsToTeamcity` -> `-DoNotImportResultsToTeamcity` (which is only used in https://github.com/red-gate/honeycomb-wpf/blob/master/.build/build.ps1).