### PR TITLE
Include all NUnit processes

### DIFF
--- a/Public/Invoke-NUnit3ForAssembly.ps1
+++ b/Public/Invoke-NUnit3ForAssembly.ps1
@@ -43,7 +43,7 @@ function Invoke-NUnit3ForAssembly {
     # The dotcover filters passed to dotcover.exe
     [string] $DotCoverAttributeFilters = '',
     # The dotcover process filters passed to dotcover.exe. Requires dotcover version 2016.2 or later
-    [string] $DotCoverProcessFilters = '+:nunit3-console.exe',
+    [string] $DotCoverProcessFilters = '+:nunit3-console.exe;+:nunit-*.exe',
     # The working directory of the test process
     [string] $TargetWorkingDirectory
   )

--- a/Public/Invoke-NUnitForAssembly.ps1
+++ b/Public/Invoke-NUnitForAssembly.ps1
@@ -45,7 +45,7 @@ function Invoke-NUnitForAssembly {
     # The dotcover filters passed to dotcover.exe
     [string] $DotCoverAttributeFilters = '',
     # The dotcover process filters passed to dotcover.exe. Requires dotcover version 2016.2 or later
-    [string] $DotCoverProcessFilters = '+:nunit-console.exe;+:nunit-console-x86.exe',
+    [string] $DotCoverProcessFilters = '+:nunit-*.exe',
     # If set, do not import test results automatically to Teamcity.
     # In this case it is the responsibility of the caller to call 'TeamCity-ImportNUnitReport "$AssemblyPath.$TestResultFilenamePattern.xml"'
     [switch] $DoNotImportResultsToTeamcity


### PR DESCRIPTION
Turns out my previous PR (#110) broke code coverage because it only included `nunit3-console.exe`, and not the agent process that actually runs the tests. So we got no code coverage. Only SQL Clone updated to RedGate.Build 1.0.0 so far, so I don't think this will have broken anyone else so far, thankfully!