### PR TITLE
Cmdlet to normalize AssemblyInfo.cs files

### DIFF
--- a/Public/Rewrite-AssemblyInfo.ps1
+++ b/Public/Rewrite-AssemblyInfo.ps1
@@ -47,9 +47,9 @@ $AssemblyAttributeThemeInfoRegex = '^\[\s*assembly\s*:\s*ThemeInfo\s*\(\s*(Resou
 
 <#
 .SYNOPSIS
-  Rewrites an AssemblyInfo file in a standardized, opitionated way.
+  Rewrites an AssemblyInfo file in a standardized, opinionated way.
 .DESCRIPTION
-  Rewrites an AssemblyInfo file in a standardized, opitionated way. AssemblyDescription, ComVisible, Guid, BootstrapperApplication, ThemeInfo, and InternalsVisibleTo are preserved, but all other properties are standardized. But, if the original AssemblyInfo.cs file contains unexpected/custom contents, then this cmdlet will throw an error, to avoid overriding intended changes.
+  Rewrites an AssemblyInfo file in a standardized, opinionated way. AssemblyDescription, ComVisible, Guid, BootstrapperApplication, ThemeInfo, and InternalsVisibleTo are preserved, but all other properties are standardized. But, if the original AssemblyInfo.cs file contains unexpected/custom contents, then this cmdlet will throw an error, to avoid overriding intended changes.
 .NOTES
   This cmdlet standardises AssemblyInfo.cs properties to the following:
   AssemblyTitle = project name

--- a/Public/Rewrite-AssemblyInfo.ps1
+++ b/Public/Rewrite-AssemblyInfo.ps1
@@ -49,10 +49,11 @@ $AssemblyAttributeThemeInfoRegex = '^\[\s*assembly\s*:\s*ThemeInfo\s*\(\s*(Resou
 .SYNOPSIS
   Rewrites an AssemblyInfo file in a standardized, opitionated way.
 .DESCRIPTION
-  Rewrites an AssemblyInfo file in a standardized, opitionated way. ComVisible, Guid, BootstrapperApplication, ThemeInfo, and InternalsVisibleTo are preserved, but all other properties are standardized. But, if the original AssemblyInfo.cs file contains unexpected/custom contents, then this cmdlet will throw an error, to avoid overriding intended changes.
+  Rewrites an AssemblyInfo file in a standardized, opitionated way. AssemblyDescription, ComVisible, Guid, BootstrapperApplication, ThemeInfo, and InternalsVisibleTo are preserved, but all other properties are standardized. But, if the original AssemblyInfo.cs file contains unexpected/custom contents, then this cmdlet will throw an error, to avoid overriding intended changes.
 .NOTES
   This cmdlet standardises AssemblyInfo.cs properties to the following:
   AssemblyTitle = project name
+  AssemblyDescription = preserved
   AssemblyCompany = "Red Gate Software Ltd"
   AssemblyProduct = product name from -ProductName or -ProductNameOverrides
   AssemblyCopyright = "Copyright © Red Gate Software Ltd <year from -Year>"

--- a/Public/Rewrite-AssemblyInfo.ps1
+++ b/Public/Rewrite-AssemblyInfo.ps1
@@ -143,7 +143,7 @@ function Rewrite-AssemblyInfo {
     if ($data.AssemblyConfiguration -and $data.AssemblyConfiguration -ne '""') { throw "Unexpected AssemblyConfiguration in $($filename): $($data.AssemblyConfiguration)" }
     if ($data.AssemblyCompany -and $data.AssemblyCompany -ne '""' -and $data.AssemblyCompany -ne '"Red Gate Software Ltd"') { throw "Unexpected AssemblyCompany in $($filename): $($data.AssemblyCompany) instead of ""Red Gate Software Ltd""" }
     $output += '[assembly: AssemblyCompany("Red Gate Software Ltd")]' + [System.Environment]::NewLine
-    if ($data.AssemblyProduct -and $data.AssemblyProduct -ne '""' -and $data.AssemblyProduct -ne '"' + $ProjectName + '"') { throw "Unexpected AssemblyProduct in $($filename): $($data.AssemblyProduct) instead of ""$correctProductName""" }
+    if ($data.AssemblyProduct -and $data.AssemblyProduct -ne '""' -and $data.AssemblyProduct -ne '"' + $ProjectName + '"' -and $data.AssemblyProduct -ne '"' + $ProductName + '"') { throw "Unexpected AssemblyProduct in $($filename): $($data.AssemblyProduct) instead of ""$ProductName""" }
     $output += '[assembly: AssemblyProduct("' + $ProductName + '")]' + [System.Environment]::NewLine
     if ($data.AssemblyCopyright -and $data.AssemblyCopyright -ne '""' -and -not $data.AssemblyCopyright -match '"Copyright ©  20[1-9][0-9]"' -and -not $data.AssemblyCopyright -match '"Copyright © Red Gate Software Ltd 20[1-9][0-9]"') { throw "Unexpected AssemblyCopyright in $($filename): $($data.AssemblyCopyright) instead of ""Copyright © Red Gate Software Ltd $year""" }
     $output += '[assembly: AssemblyCopyright("Copyright © Red Gate Software Ltd ' + $year + '")]' + [System.Environment]::NewLine

--- a/Public/Rewrite-AssemblyInfo.ps1
+++ b/Public/Rewrite-AssemblyInfo.ps1
@@ -1,0 +1,182 @@
+﻿# These are default comments that Visual Studio includes in AssemblyInfo.cs, and are thus uninteresting.
+$AssemblyInfoCommentsToIgnore = @(
+    '// General Information about an assembly is controlled through the following',
+    '// set of attributes. Change these attribute values to modify the information',
+    '// associated with an assembly.',
+    '// Setting ComVisible to false makes the types in this assembly not visible',
+    '// to COM components.  If you need to access a type in this assembly from',
+    '// COM, set the ComVisible attribute to true on that type.',
+    '// The following GUID is for the ID of the typelib if this project is exposed to COM',
+    '// Version information for an assembly consists of the following four values:',
+    '//',
+    '//      Major Version',
+    '//      Minor Version',
+    '//      Build Number',
+    '//      Revision',
+    '// You can specify all the values or you can default the Build and Revision Numbers',
+    "// by using the '*' as shown below:",
+    '// [assembly: AssemblyVersion("1.0.*")]',
+    '//In order to begin building localizable applications, set',
+    '//<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file',
+    '//inside a <PropertyGroup>.  For example, if you are using US english',
+    '//in your source files, set the <UICulture> to en-US.  Then uncomment',
+    '//the NeutralResourceLanguage attribute below.  Update the "en-US" in',
+    '//the line below to match the UICulture setting in the project file.',
+    '//[assembly: NeutralResourcesLanguage("en-US", UltimateResourceFallbackLocation.Satellite)]',
+    '//(used if a resource is not found in the page,',
+    '// or application resource dictionaries)',
+    '//(used if a resource is not found in the page,',
+    '// app, or any theme specific resource dictionaries)'
+)
+
+# Visual Studio puts the ThemeInfo attribute on multiple lines with comments, which is hard to parse later.
+# This function uses multiline regexes to collapse it to one line without comments to make parsing easier.
+function CollapseDefaultThemeInfoToOneLine([String] $assemblyInfo) {
+    return $assemblyInfo `
+        -replace '(?m)//\s*where theme specific resource dictionaries are located\s*$', '' `
+        -replace '(?m)//\s*\(used if a resource is not found in the page,\s*$', '' `
+        -replace '(?m)//\s*or application resource dictionaries\)\s*$', '' `
+        -replace '(?m)//\s*where the generic resource dictionary is located\s*$', '' `
+        -replace '(?m)//\s*app, or any theme specific resource dictionaries\)\s*$', '' `
+        -replace '(?m)^\s*\[\s*assembly\s*:\s*ThemeInfo\s*\(\s*(ResourceDictionaryLocation\.(None|SourceAssembly|ExternalAssembly))\s*,\s*(ResourceDictionaryLocation\.(None|SourceAssembly|ExternalAssembly))\s*\)\s*\]\s*$', '[assembly: ThemeInfo($1, $3)]'
+}
+
+$UsingStatementRegex = '^using\s+[\w.]+\s*;$'
+$AssemblyAttributeSingleParameterRegex = '^\[\s*assembly\s*:\s*(\w+)\s*\(\s*(\w*|typeof\(\w+\)|"([^"\\])*")\s*\)\s*\]$'
+$AssemblyAttributeThemeInfoRegex = '^\[\s*assembly\s*:\s*ThemeInfo\s*\(\s*(ResourceDictionaryLocation\.(None|SourceAssembly|ExternalAssembly))\s*,\s*(ResourceDictionaryLocation\.(None|SourceAssembly|ExternalAssembly))\s*\)\s*\]$'
+
+<#
+.SYNOPSIS
+  Rewrites an AssemblyInfo file in a standardized, opitionated way.
+.DESCRIPTION
+  Rewrites an AssemblyInfo file in a standardized, opitionated way. ComVisible, Guid, BootstrapperApplication, ThemeInfo, and InternalsVisibleTo are preserved, but all other properties are standardized. But, if the original AssemblyInfo.cs file contains unexpected/custom contents, then this cmdlet will throw an error, to avoid overriding intended changes.
+.NOTES
+  This cmdlet standardises AssemblyInfo.cs properties to the following:
+  AssemblyTitle = project name
+  AssemblyCompany = "Red Gate Software Ltd"
+  AssemblyProduct = product name from -ProductName or -ProductNameOverrides
+  AssemblyCopyright = "Copyright © Red Gate Software Ltd <year from -Year>"
+  ComVisible = preserved, or false if not present before
+  Guid = preserved
+  AssemblyVersion = version from -Version or -VersionOverrides
+  AssemblyFileVersion = version from -Version or -VersionOverrides
+  BootstrapperApplication = preserved
+  ThemeInfo = preserved
+  InternalsVisibleTo = preserved
+.PARAMETER ProjectName
+  The name of the project file, eg 'RedGate.SqlClone.Core'.
+.PARAMETER ProductName
+  The name of the product, eg 'SQL Clone'.
+.PARAMETER RootNamespace
+  The root namespace of the project, eg 'RedGate.SqlClone.Core'. This is currently only used for WiX Bootstrapper projects.
+.PARAMETER AssemblyInfoPath
+  The path of the AssemblyInfo.cs file to rewrite.
+.PARAMETER Version
+  The version of the assembly.
+.PARAMETER Year
+  The copyright year.
+#>
+function Rewrite-AssemblyInfo {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)][string] $ProjectName,
+        [Parameter(Mandatory = $true)][string] $ProductName,
+        [Parameter(Mandatory = $false)][string] $RootNamespace,
+        [Parameter(Mandatory = $true)][string] $AssemblyInfoPath,
+        [Parameter(Mandatory = $true)][System.Version] $Version,
+        [Parameter(Mandatory = $true)][int] $Year
+    )
+    
+    $filename = $AssemblyInfoPath
+    $rawinput = Get-Content $filename -Raw
+    $input = (CollapseDefaultThemeInfoToOneLine($rawinput)).Split("`r`n")
+    $usings = New-Object System.Collections.Generic.SortedSet[string]
+    $usings.Add('System.Reflection') | Out-Null
+    $usings.Add('System.Runtime.InteropServices') | Out-Null
+    $output = ''
+    $data = @{ InternalsVisibleTo = New-Object System.Collections.Generic.SortedSet[string] }
+    foreach ($line in $input) {
+        $line = $line.Trim()
+        if ($line -eq '') { continue }
+        if ($AssemblyInfoCommentsToIgnore.Contains($line)) { continue }
+        if ($line -match $UsingStatementRegex) { continue }
+        if ($line -match $AssemblyAttributeSingleParameterRegex) {
+            switch ($matches[1]) {
+                { @('AssemblyCompany', 'AssemblyConfiguration', 'AssemblyCopyright', 'AssemblyCulture', 'AssemblyDescription', 'AssemblyFileVersion', 'AssemblyProduct', 'AssemblyTitle', 'AssemblyTrademark', 'AssemblyVersion', 'ComVisible', 'Guid') -contains $_ } {
+                    assert ($null -eq $data[$_]) "$_ is set multiple times in $filename"
+                    $data[$_] = $matches[2]
+                }
+                BootstrapperApplication {
+                    assert ($null -eq $data.BootstrapperApplication) "BootstrapperApplication is set multiple times in $filename"
+                    $data.BootstrapperApplication = $matches[2]
+                    $usings.Add('Microsoft.Tools.WindowsInstallerXml.Bootstrapper') | Out-Null
+                    if ($RootNamespace) {
+                        $usings.Add($RootNamespace) | Out-Null
+                    }
+                }
+                InternalsVisibleTo {
+                    $data.InternalsVisibleTo.Add($matches[2]) | Out-Null
+                    $usings.Add('System.Runtime.CompilerServices') | Out-Null
+                }
+                default {
+                    assert $false "Unknown attribute $_ in $filename"
+                }
+            }
+            continue
+        }
+        if ($line -match $AssemblyAttributeThemeInfoRegex) {
+            assert ($null -eq $data.ThemeInfo) "ThemeInfo is set multiple times in $filename"
+            $data.ThemeInfo = $matches[1] + ', ' + $matches[3]
+            $usings.Add('System.Windows') | Out-Null
+            continue
+        }
+        throw "Unexpected line in $($filename):" + [System.Environment]::NewLine + $line
+    }
+    
+    $output = $usings | Where-Object { $_.StartsWith('System.') } | ForEach-Object { "using $_;" } | out-string
+    $output += $usings | Where-Object { -not $_.StartsWith('System.') } | ForEach-Object { "using $_;" } | out-string
+    $output += [System.Environment]::NewLine
+    if ($data.AssemblyTitle) { assert ($data.AssemblyTitle -eq '"' + $ProjectName + '"') "Unexpected AssemblyTitle in $($filename): $($data.AssemblyTitle) instead of ""$ProjectName""" }
+    $output += '[assembly: AssemblyTitle("' + $ProjectName + '")]' + [System.Environment]::NewLine
+    if ($data.AssemblyDescription -and $data.AssemblyDescription -ne '""') { $output += '[assembly: AssemblyDescription(' + $data.AssemblyDescription + ')]' + [System.Environment]::NewLine }
+    if ($data.AssemblyConfiguration -and $data.AssemblyConfiguration -ne '""') { assert ($data.AssemblyConfiguration -eq '""') "Unexpected AssemblyConfiguration in $($filename): $($data.AssemblyConfiguration)" }
+    if ($data.AssemblyCompany -and $data.AssemblyCompany -ne '""') { assert ($data.AssemblyCompany -eq '"Red Gate Software Ltd"') "Unexpected AssemblyCompany in $($filename): $($data.AssemblyCompany) instead of ""Red Gate Software Ltd""" }
+    $output += '[assembly: AssemblyCompany("Red Gate Software Ltd")]' + [System.Environment]::NewLine
+    if ($data.AssemblyProduct -and $data.AssemblyProduct -ne '""' -and $data.AssemblyProduct -ne '"' + $ProjectName + '"') { assert ($data.AssemblyProduct -eq '"' + $ProductName + '"') "Unexpected AssemblyProduct in $($filename): $($data.AssemblyProduct) instead of ""$correctProductName""" }
+    $output += '[assembly: AssemblyProduct("' + $ProductName + '")]' + [System.Environment]::NewLine
+    if ($data.AssemblyCopyright -and $data.AssemblyCopyright -ne '""' -and -not $data.AssemblyCopyright -match '"Copyright ©  20[1-9][0-9]"') { assert ($data.AssemblyCopyright -match '"Copyright © Red Gate Software Ltd 20[1-9][0-9]"') "Unexpected AssemblyCopyright in $($filename): $($data.AssemblyCopyright) instead of ""Copyright © Red Gate Software Ltd $year""" }
+    $output += '[assembly: AssemblyCopyright("Copyright © Red Gate Software Ltd ' + $year + '")]' + [System.Environment]::NewLine
+    if ($data.AssemblyTrademark -and $data.AssemblyTrademark -ne '""') { assert ($data.AssemblyTrademark -eq '""') "Unexpected AssemblyTrademark in $($filename): $($data.AssemblyTrademark)" }
+    if ($data.AssemblyCulture -and $data.AssemblyCulture -ne '""') { assert ($data.AssemblyCulture -eq '""') "Unexpected AssemblyCulture in $($filename): $($data.AssemblyCulture)" }
+
+    $output += [System.Environment]::NewLine
+    $ComVisible = if ($data.ComVisible) { $data.ComVisible } else { 'false' }
+    $output += '[assembly: ComVisible(' + $ComVisible + ')]' + [System.Environment]::NewLine
+    assert ($null -ne $data.Guid) "Guid not set in $filename"
+    $output += '[assembly: Guid(' + $data.Guid + ')]' + [System.Environment]::NewLine
+
+    if ($data.ThemeInfo) {
+        $output += [System.Environment]::NewLine + '[assembly: ThemeInfo(' + $data.ThemeInfo + ')]' + [System.Environment]::NewLine
+    }
+
+    if ($data.BootstrapperApplication) {
+        $output += [System.Environment]::NewLine + '[assembly: BootstrapperApplication(' + $data.BootstrapperApplication + ')]' + [System.Environment]::NewLine
+    }
+
+    $output += @"
+
+[assembly: AssemblyVersion("$Version")]
+[assembly: AssemblyFileVersion("$Version")]
+
+"@
+
+    if ($data.InternalsVisibleTo.Count -ge 1) {
+        $output += [System.Environment]::NewLine
+        $output += $data.InternalsVisibleTo | ForEach-Object { "[assembly: InternalsVisibleTo($_)]" } | Out-String
+    }
+
+    $output = $output.TrimEnd()
+    if ($output -ne $rawinput.TrimEnd()) {
+        $output | Out-File $filename -Encoding UTF8
+    }
+}

--- a/Public/Rewrite-AssemblyInfo.ps1
+++ b/Public/Rewrite-AssemblyInfo.ps1
@@ -153,8 +153,12 @@ function Rewrite-AssemblyInfo {
     $output += [System.Environment]::NewLine
     $ComVisible = if ($data.ComVisible) { $data.ComVisible } else { 'false' }
     $output += '[assembly: ComVisible(' + $ComVisible + ')]' + [System.Environment]::NewLine
-    if ($null -eq $data.Guid) { throw "Guid not set in $filename" }
-    $output += '[assembly: Guid(' + $data.Guid + ')]' + [System.Environment]::NewLine
+    if ($null -eq $data.Guid) {
+        if ($ComVisible -ne 'false') { throw "Guid not set in $filename despite ComVisible being $ComVisible" }
+    }
+    else {
+        $output += '[assembly: Guid(' + $data.Guid + ')]' + [System.Environment]::NewLine
+    }
 
     if ($data.ThemeInfo) {
         $output += [System.Environment]::NewLine + '[assembly: ThemeInfo(' + $data.ThemeInfo + ')]' + [System.Environment]::NewLine

--- a/Public/Rewrite-AssemblyInfos.ps1
+++ b/Public/Rewrite-AssemblyInfos.ps1
@@ -1,0 +1,78 @@
+﻿<#
+.SYNOPSIS
+  Rewrites all the AssemblyInfo files in a solution in a standardized, opitionated way.
+.DESCRIPTION
+  Rewrites all the AssemblyInfo files in a solution in a standardized, opitionated way. If any of the original AssemblyInfo.cs files contains unexpected/custom contents, then this cmdlet will throw an error, to avoid overriding intended changes. This cmdlet should be used on a solution before the solution is compiled, so that the compiled assemblies properties are correctly set.
+.NOTES
+  This cmdlet standardises AssemblyInfo.cs properties to the following:
+  AssemblyTitle = project name
+  AssemblyCompany = "Red Gate Software Ltd"
+  AssemblyProduct = product name from -ProductName or -ProductNameOverrides
+  AssemblyCopyright = "Copyright © Red Gate Software Ltd <year from -Year>"
+  ComVisible = preserved, or false if not present before
+  Guid = preserved
+  AssemblyVersion = version from -Version or -VersionOverrides
+  AssemblyFileVersion = version from -Version or -VersionOverrides
+  BootstrapperApplication = preserved
+  ThemeInfo = preserved
+  InternalsVisibleTo = preserved
+.PARAMETER SolutionFile
+  The path to the solution file.
+.PARAMETER ProductName
+  The name of the product, eg 'SQL Clone'.
+.PARAMETER Version
+  The version of the product.
+.PARAMETER Year
+  The copyright year.
+.PARAMETER ProductNameOverrides
+  A hashtable from project name (eg 'RedGate.SqlDummy.Core') to product name, if some DLLs within a solution should have a different product name to the rest.
+.PARAMETER VersionOverrides
+  A hashtable from project name (eg 'RedGate.SqlDummy.Core') to version, if some DLLs within a solution should have a different version to the rest.
+.EXAMPLE
+  $year = git log -1 --format=%cd --date=format:%Y
+  Rewrite-AssemblyInfos -SolutionFile $SolutionFile -ProductName 'SQL Compare' -Version $Version -Year $year
+
+  This shows basic usage, where there is only one product name and version, and the year is based off the last git commit.
+.EXAMPLE
+  $year = git log -1 --format=%cd --date=format:%Y
+  $productNameOverrides = @{
+    'RedGate.Owin.Html5Mode' = 'RedGate.Owin.Html5Mode'
+    'RedGate.Owin.Html5Mode.Tests' = 'RedGate.Owin.Html5Mode'
+  }
+  $versionOverrides = @{
+    'RedGate.SqlClone.PowerShell' = $PsVersion
+  }
+  Rewrite-AssemblyInfos -SolutionFile $SolutionFile -ProductName 'SQL Clone' -Version $Version -Year $year -ProductNameOverrides $productNameOverrides -VersionOverrides $versionOverrides
+
+  This shows more advanced usage, where some DLLs have a different product name or version.
+#>
+function Rewrite-AssemblyInfos {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)][string] $SolutionFile,
+        [Parameter(Mandatory = $true)][string] $ProductName,
+        [Parameter(Mandatory = $true)][System.Version] $Version,
+        [Parameter(Mandatory = $true)][int] $Year,
+        [Parameter(Mandatory = $false)][Hashtable] $ProductNameOverrides,
+        [Parameter(Mandatory = $false)][Hashtable] $VersionOverrides
+    )
+    
+    $projects = Get-ProjectsFromSolution $SolutionFile | Where-Object { $_.Project.EndsWith('.csproj') }
+    $assemblyInfos = $projects | ForEach-Object { return @{
+            Project      = $_.Project
+            AssemblyInfo = $_.Project -replace '(\\|/|^)[^\\]+$', '\Properties\AssemblyInfo.cs'
+        } }
+    $missingAssemblyInfos = $assemblyInfos | Where-Object { !(Test-Path $_.AssemblyInfo) }
+    assert ($null -eq $missingAssemblyInfos) @"
+Some projects are missing AssemblyInfo files:
+$($missingAssemblyInfos | Out-String)
+"@
+    $assemblyInfos | ForEach-Object {
+        $xml = [xml] (Get-Content $_.Project)
+        $projectname = $xml.Project.PropertyGroup.AssemblyName | Where-Object { $_ }
+        $rootnamespace = $xml.Project.PropertyGroup.RootNamespace | Where-Object { $_ }
+        $v = if ($VersionOverrides -and $VersionOverrides[$ProjectName]) { $VersionOverrides[$ProjectName] } else { $Version }
+        $thisproductname = if ($ProductNameOverrides -and $ProductNameOverrides[$ProjectName]) { $ProductNameOverrides[$ProjectName] } else { $ProductName }
+        Rewrite-AssemblyInfo -ProjectName $projectname -ProductName $thisproductname -RootNamespace $rootnamespace -AssemblyInfoPath $_.AssemblyInfo -Version $v -Year $year
+    }
+}

--- a/Public/Rewrite-AssemblyInfos.ps1
+++ b/Public/Rewrite-AssemblyInfos.ps1
@@ -1,21 +1,8 @@
 ﻿<#
 .SYNOPSIS
-  Rewrites all the AssemblyInfo files in a solution in a standardized, opitionated way.
+  Rewrites all the AssemblyInfo files in a solution in a standardized, opinionated way.
 .DESCRIPTION
-  Rewrites all the AssemblyInfo files in a solution in a standardized, opitionated way. If any of the original AssemblyInfo.cs files contains unexpected/custom contents, then this cmdlet will throw an error, to avoid overriding intended changes. This cmdlet should be used on a solution before the solution is compiled, so that the compiled assemblies properties are correctly set.
-.NOTES
-  This cmdlet standardises AssemblyInfo.cs properties to the following:
-  AssemblyTitle = project name
-  AssemblyCompany = "Red Gate Software Ltd"
-  AssemblyProduct = product name from -ProductName or -ProductNameOverrides
-  AssemblyCopyright = "Copyright © Red Gate Software Ltd <year from -Year>"
-  ComVisible = preserved, or false if not present before
-  Guid = preserved
-  AssemblyVersion = version from -Version or -VersionOverrides
-  AssemblyFileVersion = version from -Version or -VersionOverrides
-  BootstrapperApplication = preserved
-  ThemeInfo = preserved
-  InternalsVisibleTo = preserved
+  Rewrites all the AssemblyInfo files in a solution in a standardized, opinionated way. See the description & notes of Rewrite-AssemblyInfo for more information. If any of the original AssemblyInfo.cs files contains unexpected/custom contents, then this cmdlet will throw an error, to avoid overriding intended changes. This cmdlet should be used on a solution before the solution is compiled, so that the compiled assemblies properties are correctly set.
 .PARAMETER SolutionFile
   The path to the solution file.
 .PARAMETER ProductName

--- a/Public/Rewrite-AssemblyInfos.ps1
+++ b/Public/Rewrite-AssemblyInfos.ps1
@@ -63,10 +63,12 @@ function Rewrite-AssemblyInfos {
             AssemblyInfo = $_.Project -replace '(\\|/|^)[^\\]+$', '\Properties\AssemblyInfo.cs'
         } }
     $missingAssemblyInfos = $assemblyInfos | Where-Object { !(Test-Path $_.AssemblyInfo) }
-    assert ($null -eq $missingAssemblyInfos) @"
+    if ($null -ne $missingAssemblyInfos) {
+        throw @"
 Some projects are missing AssemblyInfo files:
 $($missingAssemblyInfos | Out-String)
 "@
+    }
     $assemblyInfos | ForEach-Object {
         $xml = [xml] (Get-Content $_.Project)
         $projectname = $xml.Project.PropertyGroup.AssemblyName | Where-Object { $_ }

--- a/Tests/Rewrite-AssemblyInfo.Tests.ps1
+++ b/Tests/Rewrite-AssemblyInfo.Tests.ps1
@@ -351,4 +351,31 @@ using System.Runtime.InteropServices;
             $actualOutput | Should Be $expectedOutput
         }
     }
+    Context 'Empty AssemblyInfo.cs' {
+        $initialAssemblyInfo = @"
+
+"@
+        $expectedOutput = @"
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("NewProject")]
+[assembly: AssemblyCompany("Red Gate Software Ltd")]
+[assembly: AssemblyProduct("SQL Dummy")]
+[assembly: AssemblyCopyright("Copyright © Red Gate Software Ltd 2019")]
+
+[assembly: ComVisible(false)]
+
+[assembly: AssemblyVersion("1.2.3.456")]
+[assembly: AssemblyFileVersion("1.2.3.456")]
+
+"@
+        It 'Should write minimal AssemblyInfo.cs' {
+            $filename = (New-TemporaryFile).FullName
+            $initialAssemblyInfo | Out-File $filename -Encoding UTF8
+            Rewrite-AssemblyInfo -ProjectName 'NewProject' -ProductName 'SQL Dummy' -RootNamespace 'NewProject' -AssemblyInfoPath $filename -Version '1.2.3.456' -Year '2019'
+            $actualOutput = Get-Content $filename -Raw -Encoding UTF8
+            $actualOutput | Should Be $expectedOutput
+        }
+    }
 }

--- a/Tests/Rewrite-AssemblyInfo.Tests.ps1
+++ b/Tests/Rewrite-AssemblyInfo.Tests.ps1
@@ -304,4 +304,51 @@ using System.Runtime.InteropServices;
             $actualOutput | Should Be $expectedOutput
         }
     }
+    Context 'Custom InternalsVisibleTo' {
+        $initialAssemblyInfo = @"
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("ClassLibrary4")]
+[assembly: AssemblyCompany("Red Gate Software Ltd")]
+[assembly: AssemblyProduct("SQL Dummy")]
+[assembly: AssemblyCopyright("Copyright © Red Gate Software Ltd 2018")]
+
+[assembly: ComVisible(false)]
+
+[assembly: AssemblyVersion("1.2.3.456")]
+[assembly: AssemblyFileVersion("1.2.3.456")]
+
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+[assembly: InternalsVisibleTo("ClassLibrary2")]
+
+"@
+        $expectedOutput = @"
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("ClassLibrary4")]
+[assembly: AssemblyCompany("Red Gate Software Ltd")]
+[assembly: AssemblyProduct("SQL Dummy")]
+[assembly: AssemblyCopyright("Copyright © Red Gate Software Ltd 2019")]
+
+[assembly: ComVisible(false)]
+
+[assembly: AssemblyVersion("1.2.3.456")]
+[assembly: AssemblyFileVersion("1.2.3.456")]
+
+[assembly: InternalsVisibleTo("ClassLibrary2")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+
+"@
+        It 'AssemblyDescription should be preserved' {
+            $filename = (New-TemporaryFile).FullName
+            $initialAssemblyInfo | Out-File $filename -Encoding UTF8
+            Rewrite-AssemblyInfo -ProjectName 'ClassLibrary4' -ProductName 'SQL Dummy' -RootNamespace 'ClassLibrary4' -AssemblyInfoPath $filename -Version '1.2.3.456' -Year '2019'
+            $actualOutput = Get-Content $filename -Raw -Encoding UTF8
+            $actualOutput | Should Be $expectedOutput
+        }
+    }
 }

--- a/Tests/Rewrite-AssemblyInfo.Tests.ps1
+++ b/Tests/Rewrite-AssemblyInfo.Tests.ps1
@@ -148,4 +148,75 @@ using System.Windows;
             $actualOutput | Should Be $expectedOutput
         }
     }
+    Context 'Default AssemblyInfo.cs for WiX bootstrapper projects' {
+        $initialAssemblyInfo = @"
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Microsoft.Tools.WindowsInstallerXml.Bootstrapper;
+using RedGate.SqlClone.Installer.BootstrapperApplication;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("RedGate.SqlClone.Installer.BootstrapperApplication")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("RedGate.SqlClone.Installer.BootstrapperApplication")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("f00e5a4d-9bf7-49e1-9c39-e51045904d45")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: BootstrapperApplication(typeof(NoUiBootstrapper))]
+"@
+        $expectedOutput = @"
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Microsoft.Tools.WindowsInstallerXml.Bootstrapper;
+using RedGate.SqlClone.Installer.BootstrapperApplication;
+
+[assembly: AssemblyTitle("RedGate.SqlClone.Installer.BootstrapperApplication")]
+[assembly: AssemblyCompany("Red Gate Software Ltd")]
+[assembly: AssemblyProduct("SQL Clone")]
+[assembly: AssemblyCopyright("Copyright © Red Gate Software Ltd 2019")]
+
+[assembly: ComVisible(false)]
+[assembly: Guid("f00e5a4d-9bf7-49e1-9c39-e51045904d45")]
+
+[assembly: BootstrapperApplication(typeof(NoUiBootstrapper))]
+
+[assembly: AssemblyVersion("1.2.3.456")]
+[assembly: AssemblyFileVersion("1.2.3.456")]
+
+"@
+        It 'Should rewrite minimal AssemblyInfo.cs' {
+            $filename = (New-TemporaryFile).FullName
+            $initialAssemblyInfo | Out-File $filename -Encoding UTF8
+            Rewrite-AssemblyInfo -ProjectName 'RedGate.SqlClone.Installer.BootstrapperApplication' -ProductName 'SQL Clone' -RootNamespace 'RedGate.SqlClone.Installer.BootstrapperApplication' -AssemblyInfoPath $filename -Version '1.2.3.456' -Year '2019'
+            $actualOutput = Get-Content $filename -Raw -Encoding UTF8
+            $actualOutput | Should Be $expectedOutput
+        }
+    }
 }

--- a/Tests/Rewrite-AssemblyInfo.Tests.ps1
+++ b/Tests/Rewrite-AssemblyInfo.Tests.ps1
@@ -62,6 +62,7 @@ using System.Runtime.InteropServices;
             $initialAssemblyInfo | Out-File $filename -Encoding UTF8
             Rewrite-AssemblyInfo -ProjectName 'ClassLibrary1' -ProductName 'SQL Dummy' -RootNamespace 'ClassLibrary1' -AssemblyInfoPath $filename -Version '1.2.3.456' -Year '2019'
             $actualOutput = Get-Content $filename -Raw -Encoding UTF8
+            Remove-Item $filename
             $actualOutput | Should Be $expectedOutput
         }
     }
@@ -147,6 +148,7 @@ using System.Windows;
             $initialAssemblyInfo | Out-File $filename -Encoding UTF8
             Rewrite-AssemblyInfo -ProjectName 'WpfApp1' -ProductName 'SQL Dummy' -RootNamespace 'WpfApp1' -AssemblyInfoPath $filename -Version '1.2.3.456' -Year '2019'
             $actualOutput = Get-Content $filename -Raw -Encoding UTF8
+            Remove-Item $filename
             $actualOutput | Should Be $expectedOutput
         }
     }
@@ -219,6 +221,7 @@ using RedGate.SqlClone.Installer.BootstrapperApplication;
             $initialAssemblyInfo | Out-File $filename -Encoding UTF8
             Rewrite-AssemblyInfo -ProjectName 'RedGate.SqlClone.Installer.BootstrapperApplication' -ProductName 'SQL Clone' -RootNamespace 'RedGate.SqlClone.Installer.BootstrapperApplication' -AssemblyInfoPath $filename -Version '1.2.3.456' -Year '2019'
             $actualOutput = Get-Content $filename -Raw -Encoding UTF8
+            Remove-Item $filename
             $actualOutput | Should Be $expectedOutput
         }
     }
@@ -260,6 +263,7 @@ using System.Runtime.InteropServices;
             $initialAssemblyInfo | Out-File $filename -Encoding UTF8
             Rewrite-AssemblyInfo -ProjectName 'ClassLibrary2' -ProductName 'SQL Dummy' -RootNamespace 'ClassLibrary2' -AssemblyInfoPath $filename -Version '1.2.3.456' -Year '2019'
             $actualOutput = Get-Content $filename -Raw -Encoding UTF8
+            Remove-Item $filename
             $actualOutput | Should Be $expectedOutput
         }
     }
@@ -301,6 +305,7 @@ using System.Runtime.InteropServices;
             $initialAssemblyInfo | Out-File $filename -Encoding UTF8
             Rewrite-AssemblyInfo -ProjectName 'ClassLibrary3' -ProductName 'SQL Dummy' -RootNamespace 'ClassLibrary3' -AssemblyInfoPath $filename -Version '1.2.3.456' -Year '2019'
             $actualOutput = Get-Content $filename -Raw -Encoding UTF8
+            Remove-Item $filename
             $actualOutput | Should Be $expectedOutput
         }
     }
@@ -348,6 +353,7 @@ using System.Runtime.InteropServices;
             $initialAssemblyInfo | Out-File $filename -Encoding UTF8
             Rewrite-AssemblyInfo -ProjectName 'ClassLibrary4' -ProductName 'SQL Dummy' -RootNamespace 'ClassLibrary4' -AssemblyInfoPath $filename -Version '1.2.3.456' -Year '2019'
             $actualOutput = Get-Content $filename -Raw -Encoding UTF8
+            Remove-Item $filename
             $actualOutput | Should Be $expectedOutput
         }
     }
@@ -375,6 +381,7 @@ using System.Runtime.InteropServices;
             $initialAssemblyInfo | Out-File $filename -Encoding UTF8
             Rewrite-AssemblyInfo -ProjectName 'NewProject' -ProductName 'SQL Dummy' -RootNamespace 'NewProject' -AssemblyInfoPath $filename -Version '1.2.3.456' -Year '2019'
             $actualOutput = Get-Content $filename -Raw -Encoding UTF8
+            Remove-Item $filename
             $actualOutput | Should Be $expectedOutput
         }
     }

--- a/Tests/Rewrite-AssemblyInfo.Tests.ps1
+++ b/Tests/Rewrite-AssemblyInfo.Tests.ps1
@@ -1,0 +1,67 @@
+﻿#requires -Version 4 -Modules Pester
+
+Describe 'Rewrite-AssemblyInfo' {
+    Context 'Default AssemblyInfo.cs for normal projects' {
+        $initialAssemblyInfo = @"
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ClassLibrary1")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ClassLibrary1")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("7b9e7270-e52f-4029-92cf-467917f81886")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]                
+"@
+        $expectedOutput = @"
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("ClassLibrary1")]
+[assembly: AssemblyCompany("Red Gate Software Ltd")]
+[assembly: AssemblyProduct("SQL Dummy")]
+[assembly: AssemblyCopyright("Copyright © Red Gate Software Ltd 2019")]
+
+[assembly: ComVisible(false)]
+[assembly: Guid("7b9e7270-e52f-4029-92cf-467917f81886")]
+
+[assembly: AssemblyVersion("1.2.3.456")]
+[assembly: AssemblyFileVersion("1.2.3.456")]
+
+"@
+        It 'Should rewrite minimal AssemblyInfo.cs' {
+            $filename = (New-TemporaryFile).FullName
+            $initialAssemblyInfo | Out-File $filename -Encoding UTF8
+            Rewrite-AssemblyInfo -ProjectName 'ClassLibrary1' -ProductName 'SQL Dummy' -RootNamespace 'ClassLibrary1' -AssemblyInfoPath $filename -Version '1.2.3.456' -Year '2019'
+            $actualOutput = Get-Content $filename -Raw -Encoding UTF8
+            $actualOutput | Should Be $expectedOutput
+        }
+    }
+}

--- a/Tests/Rewrite-AssemblyInfo.Tests.ps1
+++ b/Tests/Rewrite-AssemblyInfo.Tests.ps1
@@ -222,4 +222,45 @@ using RedGate.SqlClone.Installer.BootstrapperApplication;
             $actualOutput | Should Be $expectedOutput
         }
     }
+    Context 'Custom AssemblyDescription' {
+        $initialAssemblyInfo = @"
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("ClassLibrary2")]
+[assembly: AssemblyDescription("This is a custom description")]
+[assembly: AssemblyCompany("Red Gate Software Ltd")]
+[assembly: AssemblyProduct("SQL Dummy")]
+[assembly: AssemblyCopyright("Copyright © Red Gate Software Ltd 2018")]
+
+[assembly: ComVisible(false)]
+
+[assembly: AssemblyVersion("1.2.3.456")]
+[assembly: AssemblyFileVersion("1.2.3.456")]
+
+"@
+        $expectedOutput = @"
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("ClassLibrary2")]
+[assembly: AssemblyDescription("This is a custom description")]
+[assembly: AssemblyCompany("Red Gate Software Ltd")]
+[assembly: AssemblyProduct("SQL Dummy")]
+[assembly: AssemblyCopyright("Copyright © Red Gate Software Ltd 2019")]
+
+[assembly: ComVisible(false)]
+
+[assembly: AssemblyVersion("1.2.3.456")]
+[assembly: AssemblyFileVersion("1.2.3.456")]
+
+"@
+        It 'AssemblyDescription should be preserved' {
+            $filename = (New-TemporaryFile).FullName
+            $initialAssemblyInfo | Out-File $filename -Encoding UTF8
+            Rewrite-AssemblyInfo -ProjectName 'ClassLibrary2' -ProductName 'SQL Dummy' -RootNamespace 'ClassLibrary2' -AssemblyInfoPath $filename -Version '1.2.3.456' -Year '2019'
+            $actualOutput = Get-Content $filename -Raw -Encoding UTF8
+            $actualOutput | Should Be $expectedOutput
+        }
+    }
 }

--- a/Tests/Rewrite-AssemblyInfo.Tests.ps1
+++ b/Tests/Rewrite-AssemblyInfo.Tests.ps1
@@ -38,7 +38,8 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]                
+[assembly: AssemblyFileVersion("1.0.0.0")]
+
 "@
         $expectedOutput = @"
 using System.Reflection;
@@ -121,6 +122,7 @@ using System.Windows;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
 "@
         $expectedOutput = @"
 using System.Reflection;
@@ -190,6 +192,7 @@ using RedGate.SqlClone.Installer.BootstrapperApplication;
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
 [assembly: BootstrapperApplication(typeof(NoUiBootstrapper))]
+
 "@
         $expectedOutput = @"
 using System.Reflection;

--- a/Tests/Rewrite-AssemblyInfo.Tests.ps1
+++ b/Tests/Rewrite-AssemblyInfo.Tests.ps1
@@ -64,4 +64,88 @@ using System.Runtime.InteropServices;
             $actualOutput | Should Be $expectedOutput
         }
     }
+    Context 'Default AssemblyInfo.cs for WPF projects' {
+        $initialAssemblyInfo = @"
+using System.Reflection;
+using System.Resources;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Windows;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("WpfApp1")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("WpfApp1")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+//In order to begin building localizable applications, set
+//<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
+//inside a <PropertyGroup>.  For example, if you are using US english
+//in your source files, set the <UICulture> to en-US.  Then uncomment
+//the NeutralResourceLanguage attribute below.  Update the "en-US" in
+//the line below to match the UICulture setting in the project file.
+
+//[assembly: NeutralResourcesLanguage("en-US", UltimateResourceFallbackLocation.Satellite)]
+
+
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
+                                     //(used if a resource is not found in the page,
+                                     // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
+                                              //(used if a resource is not found in the page,
+                                              // app, or any theme specific resource dictionaries)
+)]
+
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+"@
+        $expectedOutput = @"
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Windows;
+
+[assembly: AssemblyTitle("WpfApp1")]
+[assembly: AssemblyCompany("Red Gate Software Ltd")]
+[assembly: AssemblyProduct("SQL Dummy")]
+[assembly: AssemblyCopyright("Copyright © Red Gate Software Ltd 2019")]
+
+[assembly: ComVisible(false)]
+
+[assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
+
+[assembly: AssemblyVersion("1.2.3.456")]
+[assembly: AssemblyFileVersion("1.2.3.456")]
+
+"@
+        It 'Should rewrite minimal AssemblyInfo.cs' {
+            $filename = (New-TemporaryFile).FullName
+            $initialAssemblyInfo | Out-File $filename -Encoding UTF8
+            Rewrite-AssemblyInfo -ProjectName 'WpfApp1' -ProductName 'SQL Dummy' -RootNamespace 'WpfApp1' -AssemblyInfoPath $filename -Version '1.2.3.456' -Year '2019'
+            $actualOutput = Get-Content $filename -Raw -Encoding UTF8
+            $actualOutput | Should Be $expectedOutput
+        }
+    }
 }

--- a/Tests/Rewrite-AssemblyInfo.Tests.ps1
+++ b/Tests/Rewrite-AssemblyInfo.Tests.ps1
@@ -263,4 +263,45 @@ using System.Runtime.InteropServices;
             $actualOutput | Should Be $expectedOutput
         }
     }
+    Context 'ComVisible set to true' {
+        $initialAssemblyInfo = @"
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("ClassLibrary3")]
+[assembly: AssemblyCompany("Red Gate Software Ltd")]
+[assembly: AssemblyProduct("SQL Dummy")]
+[assembly: AssemblyCopyright("Copyright © Red Gate Software Ltd 2018")]
+
+[assembly: ComVisible(true)]
+[assembly: Guid("89249987-80cd-4d20-aafc-d0322f2bd58a")]
+
+[assembly: AssemblyVersion("1.2.3.456")]
+[assembly: AssemblyFileVersion("1.2.3.456")]
+
+"@
+        $expectedOutput = @"
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("ClassLibrary3")]
+[assembly: AssemblyCompany("Red Gate Software Ltd")]
+[assembly: AssemblyProduct("SQL Dummy")]
+[assembly: AssemblyCopyright("Copyright © Red Gate Software Ltd 2019")]
+
+[assembly: ComVisible(true)]
+[assembly: Guid("89249987-80cd-4d20-aafc-d0322f2bd58a")]
+
+[assembly: AssemblyVersion("1.2.3.456")]
+[assembly: AssemblyFileVersion("1.2.3.456")]
+
+"@
+        It 'ComVisible should be preserved' {
+            $filename = (New-TemporaryFile).FullName
+            $initialAssemblyInfo | Out-File $filename -Encoding UTF8
+            Rewrite-AssemblyInfo -ProjectName 'ClassLibrary3' -ProductName 'SQL Dummy' -RootNamespace 'ClassLibrary3' -AssemblyInfoPath $filename -Version '1.2.3.456' -Year '2019'
+            $actualOutput = Get-Content $filename -Raw -Encoding UTF8
+            $actualOutput | Should Be $expectedOutput
+        }
+    }
 }

--- a/Tests/Rewrite-AssemblyInfos.Tests.ps1
+++ b/Tests/Rewrite-AssemblyInfos.Tests.ps1
@@ -1,0 +1,164 @@
+﻿#requires -Version 4 -Modules Pester
+
+Describe 'Rewrite-AssemblyInfos' {
+    $rootDir = New-TempDir
+    
+    $solutionFile = Join-Path $rootDir 'Rewrite-AssemblyInfos.Test.sln'
+    $normalProjectName = 'Test.NormalProject'
+    $differentProductProjectName = 'Test.ProjectWithDifferentProductName'
+    $differentVersionProjectName = 'Test.ProjectWithDifferentVersion'
+    @"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "$normalProjectName", "$normalProjectName\$normalProjectName.csproj", "{1BD528BC-3372-4BFB-9F42-39179C6F0270}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "$differentProductProjectName", "$differentProductProjectName\$differentProductProjectName.csproj", "{074559C6-669F-42FB-818E-AA687230B5F4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "$differentVersionProjectName", "$differentVersionProjectName\$differentVersionProjectName.csproj", "{85D5BBB6-7385-43C8-87D3-CE9A9E04CC64}"
+EndProject
+"@ | Out-File $solutionFile -Encoding UTF8
+    
+    $normalProjectDir = [string] (mkdir (Join-Path $rootDir $normalProjectName))
+    @"
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>$normalProjectName</AssemblyName>
+    <RootNamespace>$normalProjectName</RootNamespace>
+  </PropertyGroup>
+</Project>
+"@ | Out-File (Join-Path $normalProjectDir "$normalProjectName.csproj") -Encoding UTF8
+    $normalProjectPropertiesDir = [string] (mkdir (Join-Path $normalProjectDir 'Properties'))
+    $normalProjectAssemblyInfo = Join-Path $normalProjectPropertiesDir 'AssemblyInfo.cs'
+    @"
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("$normalProjectName")]
+[assembly: AssemblyCompany("Red Gate Software Ltd")]
+[assembly: AssemblyProduct("$normalProjectName")]
+[assembly: AssemblyCopyright("Copyright © Red Gate Software Ltd 2018")]
+
+[assembly: ComVisible(false)]
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+
+"@ | Out-File $normalProjectAssemblyInfo -Encoding UTF8
+
+    $differentProductProjectDir = [string] (mkdir (Join-Path $rootDir $differentProductProjectName))
+    @"
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>$differentProductProjectName</AssemblyName>
+    <RootNamespace>$differentProductProjectName</RootNamespace>
+  </PropertyGroup>
+</Project>
+"@ | Out-File (Join-Path $differentProductProjectDir "$differentProductProjectName.csproj") -Encoding UTF8
+    $differentProductProjectPropertiesDir = [string] (mkdir (Join-Path $differentProductProjectDir 'Properties'))
+    $differentProductProjectAssemblyInfo = Join-Path $differentProductProjectPropertiesDir 'AssemblyInfo.cs'
+    @"
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("$differentProductProjectName")]
+[assembly: AssemblyCompany("Red Gate Software Ltd")]
+[assembly: AssemblyProduct("$differentProductProjectName")]
+[assembly: AssemblyCopyright("Copyright © Red Gate Software Ltd 2018")]
+
+[assembly: ComVisible(false)]
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+
+"@ | Out-File $differentProductProjectAssemblyInfo -Encoding UTF8
+
+    $differentVersionProjectDir = [string] (mkdir (Join-Path $rootDir $differentVersionProjectName))
+    @"
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>$differentVersionProjectName</AssemblyName>
+    <RootNamespace>$differentVersionProjectName</RootNamespace>
+  </PropertyGroup>
+</Project>
+"@ | Out-File (Join-Path $differentVersionProjectDir "$differentVersionProjectName.csproj") -Encoding UTF8
+    $differentVersionProjectPropertiesDir = [string] (mkdir (Join-Path $differentVersionProjectDir 'Properties'))
+    $differentVersionProjectAssemblyInfo = Join-Path $differentVersionProjectPropertiesDir 'AssemblyInfo.cs'
+    @"
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("$differentVersionProjectName")]
+[assembly: AssemblyCompany("Red Gate Software Ltd")]
+[assembly: AssemblyProduct("$differentVersionProjectName")]
+[assembly: AssemblyCopyright("Copyright © Red Gate Software Ltd 2018")]
+
+[assembly: ComVisible(false)]
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+
+"@ | Out-File $differentVersionProjectAssemblyInfo -Encoding UTF8
+
+    $expectedNormalProjectAssemblyInfo = @"
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("$normalProjectName")]
+[assembly: AssemblyCompany("Red Gate Software Ltd")]
+[assembly: AssemblyProduct("SQL Dummy")]
+[assembly: AssemblyCopyright("Copyright © Red Gate Software Ltd 2019")]
+
+[assembly: ComVisible(false)]
+
+[assembly: AssemblyVersion("1.2.3.456")]
+[assembly: AssemblyFileVersion("1.2.3.456")]
+
+"@
+    $expectedDifferentProductProjectAssemblyInfo = @"
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("$differentProductProjectName")]
+[assembly: AssemblyCompany("Red Gate Software Ltd")]
+[assembly: AssemblyProduct("Alternate product name")]
+[assembly: AssemblyCopyright("Copyright © Red Gate Software Ltd 2019")]
+
+[assembly: ComVisible(false)]
+
+[assembly: AssemblyVersion("1.2.3.456")]
+[assembly: AssemblyFileVersion("1.2.3.456")]
+
+"@
+    $expectedDifferentVersionProjectAssemblyInfo = @"
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("$differentVersionProjectName")]
+[assembly: AssemblyCompany("Red Gate Software Ltd")]
+[assembly: AssemblyProduct("SQL Dummy")]
+[assembly: AssemblyCopyright("Copyright © Red Gate Software Ltd 2019")]
+
+[assembly: ComVisible(false)]
+
+[assembly: AssemblyVersion("2.3.4.567")]
+[assembly: AssemblyFileVersion("2.3.4.567")]
+
+"@
+    It 'Should rewrite all AssemblyInfo.cs files in solution' {
+        $productNameOverrides = @{
+            $differentProductProjectName = 'Alternate product name'
+        }
+        $versionOverrides = @{
+            $differentVersionProjectName = [Version] '2.3.4.567'
+        }
+        Rewrite-AssemblyInfos -SolutionFile $solutionFile -ProductName 'SQL Dummy' -Version '1.2.3.456' -Year '2019' -ProductNameOverrides $productNameOverrides -VersionOverrides $versionOverrides
+        $actualNormalProjectAssemblyInfo = Get-Content $normalProjectAssemblyInfo -Raw -Encoding UTF8
+        $actualNormalProjectAssemblyInfo | Should Be $expectedNormalProjectAssemblyInfo
+        $actualDifferentProductProjectAssemblyInfo = Get-Content $differentProductProjectAssemblyInfo -Raw -Encoding UTF8
+        $actualDifferentProductProjectAssemblyInfo | Should Be $expectedDifferentProductProjectAssemblyInfo
+        $actualDifferentVersionProjectAssemblyInfo = Get-Content $differentVersionProjectAssemblyInfo -Raw -Encoding UTF8
+        $actualDifferentVersionProjectAssemblyInfo | Should Be $expectedDifferentVersionProjectAssemblyInfo
+    }
+    Remove-Item -Recurse $rootDir
+}

--- a/Tests/Rewrite-AssemblyInfos.Tests.ps1
+++ b/Tests/Rewrite-AssemblyInfos.Tests.ps1
@@ -145,18 +145,22 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("2.3.4.567")]
 
 "@
-    It 'Should rewrite all AssemblyInfo.cs files in solution' {
-        $productNameOverrides = @{
-            $differentProductProjectName = 'Alternate product name'
-        }
-        $versionOverrides = @{
-            $differentVersionProjectName = [Version] '2.3.4.567'
-        }
-        Rewrite-AssemblyInfos -SolutionFile $solutionFile -ProductName 'SQL Dummy' -Version '1.2.3.456' -Year '2019' -ProductNameOverrides $productNameOverrides -VersionOverrides $versionOverrides
+    $productNameOverrides = @{
+        $differentProductProjectName = 'Alternate product name'
+    }
+    $versionOverrides = @{
+        $differentVersionProjectName = [Version] '2.3.4.567'
+    }
+    Rewrite-AssemblyInfos -SolutionFile $solutionFile -ProductName 'SQL Dummy' -Version '1.2.3.456' -Year '2019' -ProductNameOverrides $productNameOverrides -VersionOverrides $versionOverrides
+    It 'AssemblyInfo for normal project should be rewritten normally' {
         $actualNormalProjectAssemblyInfo = Get-Content $normalProjectAssemblyInfo -Raw -Encoding UTF8
         $actualNormalProjectAssemblyInfo | Should Be $expectedNormalProjectAssemblyInfo
+    }
+    It 'AssemblyInfo for project with product name override should have alternate product name' {
         $actualDifferentProductProjectAssemblyInfo = Get-Content $differentProductProjectAssemblyInfo -Raw -Encoding UTF8
         $actualDifferentProductProjectAssemblyInfo | Should Be $expectedDifferentProductProjectAssemblyInfo
+    }
+    It 'AssemblyInfo for project with version override should have alternate version' {
         $actualDifferentVersionProjectAssemblyInfo = Get-Content $differentVersionProjectAssemblyInfo -Raw -Encoding UTF8
         $actualDifferentVersionProjectAssemblyInfo | Should Be $expectedDifferentVersionProjectAssemblyInfo
     }


### PR DESCRIPTION
This PR introduces the `Rewrite-AssemblyInfos` cmdlet, which rewrites all AssemblyInfo.cs files in a solution in a standard format. This was originally written for SQL Clone, but has had the SQL Clone specific code removed and tests added, and it should now be useful for other products.