### PR TITLE
Add -Timeout to Invoke-NUnit3ForAssembly, and preserve AssemblyTitle and CLSCompliant in Rewrite-AssemblyInfo

### DIFF
--- a/Private/NUnit/3/Build-NUnit3CommandLineArguments.ps1
+++ b/Private/NUnit/3/Build-NUnit3CommandLineArguments.ps1
@@ -4,6 +4,7 @@ function Build-NUnit3CommandLineArguments {
         [Parameter(Mandatory=$true)]
         [string] $AssemblyPath,
         [bool] $x86,
+        [int] $Timeout,
         [string] $FrameworkVersion,
         [string] $Where,
         [string] $TestResultFilenamePattern = 'TestResult',
@@ -20,6 +21,10 @@ function Build-NUnit3CommandLineArguments {
         $params += "--x86"
     }
 
+    if ($Timeout) {
+        $params += "--timeout=$Timeout"
+    }
+
     if ($FrameworkVersion) {
         $params += "--framework=$FrameworkVersion"
     }
@@ -31,6 +36,6 @@ function Build-NUnit3CommandLineArguments {
     if ($ProcessIsolation) {
         $params += "--process=$ProcessIsolation"
     }
-
+    
     return $params
 }

--- a/Public/Invoke-NUnit3ForAssembly.ps1
+++ b/Public/Invoke-NUnit3ForAssembly.ps1
@@ -25,7 +25,9 @@ function Invoke-NUnit3ForAssembly {
     [string] $NUnitVersion = '3.0.0',
     # If specified, pass --x86 to nunit3-console
     [switch] $x86,
-    # If specified, the framework version to be used for tests. (pass --framework=XX to nunit3-console). e.g. 'net-4.6', 'net-4.7'
+    # If specified, the timeout for each test case in milliseconds. (passes --timeout=XX to nunit3-console.)
+    [int] $Timeout,
+    # If specified, the framework version to be used for tests. (passes --framework=XX to nunit3-console.) e.g. 'net-4.6', 'net-4.7'
     [string] $FrameworkVersion = $null,
     # NUnit3 Test selection EXPRESSION indicating what tests will be run
     # example: "method =~ /DataTest*/ && cat = Slow"
@@ -66,6 +68,7 @@ function Invoke-NUnit3ForAssembly {
     $NunitArguments = Build-NUnit3CommandLineArguments `
       -AssemblyPath $AssemblyPath `
       -x86 $x86.IsPresent `
+      -Timeout $Timeout `
       -Where $Where `
       -FrameworkVersion $FrameworkVersion `
       -TestResultFilenamePattern $TestResultFilenamePattern `

--- a/Public/Rewrite-AssemblyInfo.ps1
+++ b/Public/Rewrite-AssemblyInfo.ps1
@@ -49,18 +49,18 @@ $AssemblyAttributeThemeInfoRegex = '^\[\s*assembly\s*:\s*ThemeInfo\s*\(\s*(Resou
 .SYNOPSIS
   Rewrites an AssemblyInfo file in a standardized, opinionated way.
 .DESCRIPTION
-  Rewrites an AssemblyInfo file in a standardized, opinionated way. AssemblyDescription, ComVisible, Guid, BootstrapperApplication, ThemeInfo, and InternalsVisibleTo are preserved, but all other properties are standardized. But, if the original AssemblyInfo.cs file contains unexpected/custom contents, then this cmdlet will throw an error, to avoid overriding intended changes.
+  Rewrites an AssemblyInfo file in a standardized, opinionated way. AssemblyTitle, AssemblyDescription, ComVisible, Guid, BootstrapperApplication, ThemeInfo, and InternalsVisibleTo are preserved, but all other properties are standardized. But, if the original AssemblyInfo.cs file contains unexpected/custom contents, then this cmdlet will throw an error, to avoid overriding intended changes.
 .NOTES
   This cmdlet standardises AssemblyInfo.cs properties to the following:
-  AssemblyTitle = project name
+  AssemblyTitle = preserved if non-empty, otherwise project name
   AssemblyDescription = preserved
   AssemblyCompany = "Red Gate Software Ltd"
-  AssemblyProduct = product name from -ProductName or -ProductNameOverrides
+  AssemblyProduct = product name from -ProductName
   AssemblyCopyright = "Copyright © Red Gate Software Ltd <year from -Year>"
   ComVisible = preserved, or false if not present before
   Guid = preserved
-  AssemblyVersion = version from -Version or -VersionOverrides
-  AssemblyFileVersion = version from -Version or -VersionOverrides
+  AssemblyVersion = version from -Version
+  AssemblyFileVersion = version from -Version
   BootstrapperApplication = preserved
   ThemeInfo = preserved
   InternalsVisibleTo = preserved
@@ -137,8 +137,12 @@ function Rewrite-AssemblyInfo {
     $output = $usings | Where-Object { $_.StartsWith('System.') } | ForEach-Object { "using $_;" } | out-string
     $output += $usings | Where-Object { -not $_.StartsWith('System.') } | ForEach-Object { "using $_;" } | out-string
     $output += [System.Environment]::NewLine
-    if ($data.AssemblyTitle -and $data.AssemblyTitle -ne '"' + $ProjectName + '"') { throw "Unexpected AssemblyTitle in $($filename): $($data.AssemblyTitle) instead of ""$ProjectName""" }
-    $output += '[assembly: AssemblyTitle("' + $ProjectName + '")]' + [System.Environment]::NewLine
+    if ($data.AssemblyTitle -and $data.AssemblyTitle -ne '""') {
+        $output += '[assembly: AssemblyTitle(' + $data.AssemblyTitle + ')]' + [System.Environment]::NewLine
+    }
+    else {
+        $output += '[assembly: AssemblyTitle("' + $ProjectName + '")]' + [System.Environment]::NewLine
+    }
     if ($data.AssemblyDescription -and $data.AssemblyDescription -ne '""') { $output += '[assembly: AssemblyDescription(' + $data.AssemblyDescription + ')]' + [System.Environment]::NewLine }
     if ($data.AssemblyConfiguration -and $data.AssemblyConfiguration -ne '""') { throw "Unexpected AssemblyConfiguration in $($filename): $($data.AssemblyConfiguration)" }
     if ($data.AssemblyCompany -and $data.AssemblyCompany -ne '""' -and $data.AssemblyCompany -ne '"Red Gate Software Ltd"') { throw "Unexpected AssemblyCompany in $($filename): $($data.AssemblyCompany) instead of ""Red Gate Software Ltd""" }

--- a/Public/Rewrite-AssemblyInfo.ps1
+++ b/Public/Rewrite-AssemblyInfo.ps1
@@ -49,7 +49,7 @@ $AssemblyAttributeThemeInfoRegex = '^\[\s*assembly\s*:\s*ThemeInfo\s*\(\s*(Resou
 .SYNOPSIS
   Rewrites an AssemblyInfo file in a standardized, opinionated way.
 .DESCRIPTION
-  Rewrites an AssemblyInfo file in a standardized, opinionated way. AssemblyTitle, AssemblyDescription, ComVisible, Guid, BootstrapperApplication, ThemeInfo, and InternalsVisibleTo are preserved, but all other properties are standardized. But, if the original AssemblyInfo.cs file contains unexpected/custom contents, then this cmdlet will throw an error, to avoid overriding intended changes.
+  Rewrites an AssemblyInfo file in a standardized, opinionated way. AssemblyTitle, AssemblyDescription, ComVisible, Guid, CLSCompliant, BootstrapperApplication, ThemeInfo, and InternalsVisibleTo are preserved, but all other properties are standardized. But, if the original AssemblyInfo.cs file contains unexpected/custom contents, then this cmdlet will throw an error, to avoid overriding intended changes.
 .NOTES
   This cmdlet standardises AssemblyInfo.cs properties to the following:
   AssemblyTitle = preserved if non-empty, otherwise project name
@@ -59,6 +59,7 @@ $AssemblyAttributeThemeInfoRegex = '^\[\s*assembly\s*:\s*ThemeInfo\s*\(\s*(Resou
   AssemblyCopyright = "Copyright © Red Gate Software Ltd <year from -Year>"
   ComVisible = preserved, or false if not present before
   Guid = preserved
+  CLSCompliant = preserved
   AssemblyVersion = version from -Version
   AssemblyFileVersion = version from -Version
   BootstrapperApplication = preserved
@@ -103,7 +104,7 @@ function Rewrite-AssemblyInfo {
         if ($line -match $UsingStatementRegex) { continue }
         if ($line -match $AssemblyAttributeSingleParameterRegex) {
             switch ($matches[1]) {
-                { @('AssemblyCompany', 'AssemblyConfiguration', 'AssemblyCopyright', 'AssemblyCulture', 'AssemblyDescription', 'AssemblyFileVersion', 'AssemblyProduct', 'AssemblyTitle', 'AssemblyTrademark', 'AssemblyVersion', 'ComVisible', 'Guid') -contains $_ } {
+                { @('AssemblyCompany', 'AssemblyConfiguration', 'AssemblyCopyright', 'AssemblyCulture', 'AssemblyDescription', 'AssemblyFileVersion', 'AssemblyProduct', 'AssemblyTitle', 'AssemblyTrademark', 'AssemblyVersion', 'ComVisible', 'Guid', 'CLSCompliant') -contains $_ } {
                     if ($null -ne $data[$_]) { throw "$_ is set multiple times in $filename" }
                     $data[$_] = $matches[2]
                 }
@@ -162,6 +163,10 @@ function Rewrite-AssemblyInfo {
     }
     else {
         $output += '[assembly: Guid(' + $data.Guid + ')]' + [System.Environment]::NewLine
+    }
+    
+    if ($data.CLSCompliant) {
+        $output += '[assembly: CLSCompliant(' + $data.CLSCompliant + ')]' + [System.Environment]::NewLine
     }
 
     if ($data.ThemeInfo) {

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,7 @@
+# 1.3
+
+- `Invoke-NUnit3ForAssembly` now accepts the optional `-Timeout` parameter, which sets NUnit's `--timeout` option, setting a timeout for each test case in milliseconds.
+
 # 1.2
 
 - New `Rewrite-AssemblyInfos` cmdlet that normalizes AssemblyInfo.cs files in a standardized way

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,7 @@
 # 1.3
 
 - `Invoke-NUnit3ForAssembly` now accepts the optional `-Timeout` parameter, which sets NUnit's `--timeout` option, setting a timeout for each test case in milliseconds.
+- `Rewrite-AssemblyInfos` now preserves AssemblyTitle and CLSCompliant.
 
 # 1.2
 

--- a/Tests/Nunit/3/Build-NUnit3CommandLineArguments.Tests.ps1
+++ b/Tests/Nunit/3/Build-NUnit3CommandLineArguments.Tests.ps1
@@ -23,13 +23,14 @@ Describe 'Build-NUnit3CommandLineArguments' {
         $result = Build-NUnit3CommandLineArguments `
             -AssemblyPath 'my-test-assembly.dll' `
             -x86 $true `
+            -Timeout 30000 `
             -FrameworkVersion 'net-4.0' `
             -Where 'mywherecondition' `
             -TestResultFilenamePattern 'SpecialPattern' `
             -ProcessIsolation 'Single'
 
         It 'should return the right value' {
-            $result -join ' ' | Should Be "$(Nunit3Parameters 'my-test-assembly.dll' 'SpecialPattern') --x86 --framework=net-4.0 --where=mywherecondition --process=Single"
+            $result -join ' ' | Should Be "$(Nunit3Parameters 'my-test-assembly.dll' 'SpecialPattern') --x86 --timeout=30000 --framework=net-4.0 --where=mywherecondition --process=Single"
         }
     }
 

--- a/Tests/Rewrite-AssemblyInfo.Tests.ps1
+++ b/Tests/Rewrite-AssemblyInfo.Tests.ps1
@@ -349,6 +349,48 @@ using System.Runtime.InteropServices;
             $actualOutput | Should Be $expectedOutput
         }
     }
+    Context 'CLSCompliant set to true' {
+        $initialAssemblyInfo = @"
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("ClassLibrary3")]
+[assembly: AssemblyCompany("Red Gate Software Ltd")]
+[assembly: AssemblyProduct("SQL Dummy")]
+[assembly: AssemblyCopyright("Copyright © Red Gate Software Ltd 2018")]
+
+[assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
+
+[assembly: AssemblyVersion("1.2.3.456")]
+[assembly: AssemblyFileVersion("1.2.3.456")]
+
+"@
+        $expectedOutput = @"
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("ClassLibrary3")]
+[assembly: AssemblyCompany("Red Gate Software Ltd")]
+[assembly: AssemblyProduct("SQL Dummy")]
+[assembly: AssemblyCopyright("Copyright © Red Gate Software Ltd 2019")]
+
+[assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
+
+[assembly: AssemblyVersion("1.2.3.456")]
+[assembly: AssemblyFileVersion("1.2.3.456")]
+
+"@
+        It 'CLSCompliant should be preserved' {
+            $filename = (New-TemporaryFile).FullName
+            $initialAssemblyInfo | Out-File $filename -Encoding UTF8
+            Rewrite-AssemblyInfo -ProjectName 'ClassLibrary3' -ProductName 'SQL Dummy' -RootNamespace 'ClassLibrary3' -AssemblyInfoPath $filename -Version '1.2.3.456' -Year '2019'
+            $actualOutput = Get-Content $filename -Raw -Encoding UTF8
+            Remove-Item $filename
+            $actualOutput | Should Be $expectedOutput
+        }
+    }
     Context 'Custom InternalsVisibleTo' {
         $initialAssemblyInfo = @"
 using System.Reflection;

--- a/Tests/Rewrite-AssemblyInfo.Tests.ps1
+++ b/Tests/Rewrite-AssemblyInfo.Tests.ps1
@@ -267,6 +267,46 @@ using System.Runtime.InteropServices;
             $actualOutput | Should Be $expectedOutput
         }
     }
+    Context 'Custom AssemblyTitle' {
+        $initialAssemblyInfo = @"
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("SQL Dummy Engine")]
+[assembly: AssemblyCompany("Red Gate Software Ltd")]
+[assembly: AssemblyProduct("SQL Dummy")]
+[assembly: AssemblyCopyright("Copyright © Red Gate Software Ltd 2018")]
+
+[assembly: ComVisible(false)]
+
+[assembly: AssemblyVersion("1.2.3.456")]
+[assembly: AssemblyFileVersion("1.2.3.456")]
+
+"@
+        $expectedOutput = @"
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("SQL Dummy Engine")]
+[assembly: AssemblyCompany("Red Gate Software Ltd")]
+[assembly: AssemblyProduct("SQL Dummy")]
+[assembly: AssemblyCopyright("Copyright © Red Gate Software Ltd 2019")]
+
+[assembly: ComVisible(false)]
+
+[assembly: AssemblyVersion("1.2.3.456")]
+[assembly: AssemblyFileVersion("1.2.3.456")]
+
+"@
+        It 'AssemblyTitle should be preserved' {
+            $filename = (New-TemporaryFile).FullName
+            $initialAssemblyInfo | Out-File $filename -Encoding UTF8
+            Rewrite-AssemblyInfo -ProjectName 'ClassLibrary2' -ProductName 'SQL Dummy' -RootNamespace 'ClassLibrary2' -AssemblyInfoPath $filename -Version '1.2.3.456' -Year '2019'
+            $actualOutput = Get-Content $filename -Raw -Encoding UTF8
+            Remove-Item $filename
+            $actualOutput | Should Be $expectedOutput
+        }
+    }
     Context 'ComVisible set to true' {
         $initialAssemblyInfo = @"
 using System.Reflection;
@@ -348,7 +388,7 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 
 "@
-        It 'AssemblyDescription should be preserved' {
+        It 'InternalsVisibleTo should be preserved' {
             $filename = (New-TemporaryFile).FullName
             $initialAssemblyInfo | Out-File $filename -Encoding UTF8
             Rewrite-AssemblyInfo -ProjectName 'ClassLibrary4' -ProductName 'SQL Dummy' -RootNamespace 'ClassLibrary4' -AssemblyInfoPath $filename -Version '1.2.3.456' -Year '2019'


### PR DESCRIPTION
This PR contains two completely independent things, they're in one PR because I needed them at the same time as so they form RedGate.Build 1.3.

The release notes diff is as good a description as I could write here!