### PR TITLE
Allow setting AssemblyVersion and AssemblyFileVersion differently

### DIFF
--- a/Public/Rewrite-AssemblyInfo.ps1
+++ b/Public/Rewrite-AssemblyInfo.ps1
@@ -82,9 +82,11 @@ $AssemblyAttributeThemeInfoRegex = '^\[\s*assembly\s*:\s*ThemeInfo\s*\(\s*(Resou
 .PARAMETER AssemblyInfoPath
   The path of the AssemblyInfo.cs file to rewrite.
 .PARAMETER Version
-  The version of the assembly.
+  The file version of the assembly (AssemblyFileVersion).
+.PARAMETER AssemblyVersion
+  The .NET version of the assembly (AssemblyVersion).
 .PARAMETER InfoVersion
-  The informational version of the assembly.
+  The informational version of the assembly (AssemblyInformationalVersion).
 .PARAMETER Year
   The copyright year.
 #>

--- a/Public/Rewrite-AssemblyInfo.ps1
+++ b/Public/Rewrite-AssemblyInfo.ps1
@@ -41,6 +41,13 @@ function CollapseDefaultThemeInfoToOneLine([String] $assemblyInfo) {
         -replace '(?m)^\s*\[\s*assembly\s*:\s*ThemeInfo\s*\(\s*(ResourceDictionaryLocation\.(None|SourceAssembly|ExternalAssembly))\s*,\s*(ResourceDictionaryLocation\.(None|SourceAssembly|ExternalAssembly))\s*\)\s*\]\s*$', '[assembly: ThemeInfo($1, $3)]'
 }
 
+function FourPartVersion([Version] $v) {
+    if ($v.Minor -lt 0) { return [Version] "$v.0.0.0" }
+    if ($v.Build -lt 0) { return [Version] "$v.0.0" }
+    if ($v.Revision -lt 0) { return [Version] "$v.0" }
+    return $v
+}
+
 $UsingStatementRegex = '^using\s+[\w.]+\s*;$'
 $AssemblyAttributeSingleParameterRegex = '^\[\s*assembly\s*:\s*(\w+)\s*\(\s*(\w*|typeof\(\w+\)|"([^"\\])*")\s*\)\s*\]$'
 $AssemblyAttributeThemeInfoRegex = '^\[\s*assembly\s*:\s*ThemeInfo\s*\(\s*(ResourceDictionaryLocation\.(None|SourceAssembly|ExternalAssembly))\s*,\s*(ResourceDictionaryLocation\.(None|SourceAssembly|ExternalAssembly))\s*\)\s*\]$'
@@ -60,7 +67,7 @@ $AssemblyAttributeThemeInfoRegex = '^\[\s*assembly\s*:\s*ThemeInfo\s*\(\s*(Resou
   ComVisible = preserved, or false if not present before
   Guid = preserved
   CLSCompliant = preserved
-  AssemblyVersion = version from -Version
+  AssemblyVersion = version from -AssemblyVersion if set, otherwise version from -Version
   AssemblyFileVersion = version from -Version
   AssemblyInformationalVersion = version from -InfoVersion if it is set, otherwise version from -Version
   BootstrapperApplication = preserved
@@ -88,7 +95,8 @@ function Rewrite-AssemblyInfo {
         [Parameter(Mandatory = $true)][string] $ProductName,
         [Parameter(Mandatory = $false)][string] $RootNamespace,
         [Parameter(Mandatory = $true)][string] $AssemblyInfoPath,
-        [Parameter(Mandatory = $true)][System.Version] $Version,
+        [Parameter(Mandatory = $true)][Version] $Version,
+        [Parameter(Mandatory = $false)][Version] $AssemblyVersion,
         [Parameter(Mandatory = $false)][string] $InfoVersion,
         [Parameter(Mandatory = $true)][int] $Year
     )
@@ -185,14 +193,16 @@ function Rewrite-AssemblyInfo {
         $output += [System.Environment]::NewLine + '[assembly: BootstrapperApplication(' + $data.BootstrapperApplication + ')]' + [System.Environment]::NewLine
     }
 
+    $AssemblyVersion = if ($AssemblyVersion) { FourPartVersion($AssemblyVersion) } else { FourPartVersion($Version) }
+
     if (!$InfoVersion) {
-        $InfoVersion = [string] $Version
+        $InfoVersion = "$Version"
     }
     $EscapedInfoVersion = ConvertTo-CSharpEscaped $InfoVersion
     
     $output += @"
 
-[assembly: AssemblyVersion("$Version")]
+[assembly: AssemblyVersion("$AssemblyVersion")]
 [assembly: AssemblyFileVersion("$Version")]
 [assembly: AssemblyInformationalVersion("$EscapedInfoVersion")]
 

--- a/Public/Rewrite-AssemblyInfos.ps1
+++ b/Public/Rewrite-AssemblyInfos.ps1
@@ -9,6 +9,8 @@
   The name of the product, eg 'SQL Clone'.
 .PARAMETER Version
   The version of the product.
+.PARAMETER AssemblyVersionMajorOnly
+  If true, set AssemblyVersion to only contain a major version. Useful for creating semantically versioned assemblies.
 .PARAMETER InfoVersionSuffix
   The suffix to add to -Version to make the informational version. Typically set to '-<branch name>' for non-default branches.
 .PARAMETER Year

--- a/Public/Rewrite-AssemblyInfos.ps1
+++ b/Public/Rewrite-AssemblyInfos.ps1
@@ -40,7 +40,8 @@ function Rewrite-AssemblyInfos {
     param (
         [Parameter(Mandatory = $true)][string] $SolutionFile,
         [Parameter(Mandatory = $true)][string] $ProductName,
-        [Parameter(Mandatory = $true)][System.Version] $Version,
+        [Parameter(Mandatory = $true)][Version] $Version,
+        [Switch] $AssemblyVersionMajorOnly,
         [Parameter(Mandatory = $false)][string] $InfoVersionSuffix,
         [Parameter(Mandatory = $true)][int] $Year,
         [Parameter(Mandatory = $false)][Hashtable] $ProductNameOverrides,
@@ -63,9 +64,10 @@ $($missingAssemblyInfos | Out-String)
         $xml = [xml] (Get-Content $_.Project)
         $projectname = $xml.Project.PropertyGroup.AssemblyName | Where-Object { $_ }
         $rootnamespace = $xml.Project.PropertyGroup.RootNamespace | Where-Object { $_ }
-        $v = if ($VersionOverrides -and $VersionOverrides[$ProjectName]) { $VersionOverrides[$ProjectName] } else { $Version }
+        $v = if ($VersionOverrides -and $VersionOverrides[$ProjectName]) { [Version] $VersionOverrides[$ProjectName] } else { $Version }
+        $assemblyVersion = if ($AssemblyVersionMajorOnly) { [Version] "$($v.Major).0.0.0" } else { $v }
         $infoVersion = if ($InfoVersionSuffix) { "$v$InfoVersionSuffix" } else { "$v" }
         $thisproductname = if ($ProductNameOverrides -and $ProductNameOverrides[$ProjectName]) { $ProductNameOverrides[$ProjectName] } else { $ProductName }
-        Rewrite-AssemblyInfo -ProjectName $projectname -ProductName $thisproductname -RootNamespace $rootnamespace -AssemblyInfoPath $_.AssemblyInfo -Version $v -InfoVersion $infoVersion -Year $year
+        Rewrite-AssemblyInfo -ProjectName $projectname -ProductName $thisproductname -RootNamespace $rootnamespace -AssemblyInfoPath $_.AssemblyInfo -Version $v -AssemblyVersion $assemblyVersion -InfoVersion $infoVersion -Year $year
     }
 }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,41 +4,41 @@
 
 # 1.4
 
-- `Rewrite-AssemblyInfos` now writes out AssemblyInformationalVersion attribute, and takes an -InfoVersionSuffix parameter that adds a suffix to it.
+- `Rewrite-AssemblyInfos` now writes out `AssemblyInformationalVersion` attribute, and takes an `-InfoVersionSuffix` parameter that adds a suffix to it.
 
 # 1.3
 
 - `Invoke-NUnit3ForAssembly` now accepts the optional `-Timeout` parameter, which sets NUnit's `--timeout` option, setting a timeout for each test case in milliseconds.
-- `Rewrite-AssemblyInfos` now preserves AssemblyTitle and CLSCompliant.
+- `Rewrite-AssemblyInfos` now preserves `AssemblyTitle` and `CLSCompliant`.
 
 # 1.2
 
-- New `Rewrite-AssemblyInfos` cmdlet that normalizes AssemblyInfo.cs files in a standardized way
+- New `Rewrite-AssemblyInfos` cmdlet that normalizes AssemblyInfo.cs files in a standardized way.
 
 # 1.1
 
-- `Invoke-NUnit3ForAssembly` now accepts the optional `-ProcessIsolation` parameter, which sets NUnit's `--process` option
+- `Invoke-NUnit3ForAssembly` now accepts the optional `-ProcessIsolation` parameter, which sets NUnit's `--process` option.
 
 # 1.0
 
 - `Invoke-NUnitForAssembly` and `Invoke-NUnit3ForAssembly`, when run with code coverage enabled, by default only cover the NUnit process itself, any not any subprocesses. This can be overridden using the `-DotCoverProcessFilters` parameter.
 - `-DotNotImportResultsToTeamcity` has been renamed to `-DoNotImportResultsToTeamcity` (removing the extra t).
-- Fixed issues where certain cmdlets where not working for pipelines
+- Fixed issues where certain cmdlets where not working for pipelines.
 
 # 0.6
 
 - `Update-NuspecDependenciesVersions` now accepts the `-SpecificVersions` switch. Using the switch will use a specific version rather than a range for dependencies with three-part version numbers.
-- `Invoke-NUnit3ForAssembly` and `Invoke-DotCoverForExecutable` now accept the optional `-TargetWorkingDirectory` parameter to specify the working directory for the tests to run in
-- `Remove-IgnoredTests` now supports the NUnit 3 results xml format and uses an xslt transform to perform the removal
+- `Invoke-NUnit3ForAssembly` and `Invoke-DotCoverForExecutable` now accept the optional `-TargetWorkingDirectory` parameter to specify the working directory for the tests to run in.
+- `Remove-IgnoredTests` now supports the NUnit 3 results xml format and uses an xslt transform to perform the removal.
 
 # 0.5
 
-- New `Update-ProjectProperties` cmdlet that can be used to set various properties of a C# project file, such as Version, AssemblyVersion, FileVersion and PackageReleaseNotes. This provides an alternative to `Update-AssemblyVersion` as we progressively move away from using `AssemblyInfo.cs` files for project properties.
+- New `Update-ProjectProperties` cmdlet that can be used to set various properties of a C# project file, such as Version, AssemblyVersion, FileVersion and PackageReleaseNotes. This provides an alternative to `Update-AssemblyVersion` as we progressively move away from using AssemblyInfo.cs files for project properties.
 - `Select-ReleaseNotes` now preserves whitespace.
 
 # 0.4
 
-- `Invoke-SigningService` will now accept a NuGet package. The NuGet package is not directly signed itself. Instead, it is unpacked to a temporary folder, all the assembly dlls in the `lib` sub-folder are signed by the signing service, and then the NuGet package is reassembled. 
+- `Invoke-SigningService` will now accept a NuGet package. The NuGet package is not directly signed itself. Instead, it is unpacked to a temporary folder, all the assembly dlls in the 'lib' sub-folder are signed by the signing service, and then the NuGet package is reassembled.
 
 # 0.3
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,7 @@
+# 1.5
+
+- `Rewrite-AssemblyInfos` now takes a `-AssemblyVersionMajorOnly` switch, which sets `AssemblyVersion` to have the major version from `-Version` and all other version parts to 0. `AssemblyFileVersion` is still always set from `-Version`.
+
 # 1.4
 
 - `Rewrite-AssemblyInfos` now writes out AssemblyInformationalVersion attribute, and takes an -InfoVersionSuffix parameter that adds a suffix to it.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,6 @@
 # 1.5
 
-- `Rewrite-AssemblyInfos` now takes a `-AssemblyVersionMajorOnly` switch, which sets `AssemblyVersion` to have the major version from `-Version` and all other version parts to 0. `AssemblyFileVersion` is still always set from `-Version`.
+- `Rewrite-AssemblyInfos` now takes an `-AssemblyVersionMajorOnly` switch, which sets `AssemblyVersion` to be "MAJOR.0.0.0", where MAJOR is the major version of the project. `AssemblyFileVersion` is still always set to the full version of the project.
 
 # 1.4
 

--- a/Tests/Rewrite-AssemblyInfo.Tests.ps1
+++ b/Tests/Rewrite-AssemblyInfo.Tests.ps1
@@ -53,7 +53,7 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("7b9e7270-e52f-4029-92cf-467917f81886")]
 
-[assembly: AssemblyVersion("1.2.3.456")]
+[assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.2.3.456")]
 [assembly: AssemblyInformationalVersion("1.2.3.456-branch-suffix")]
 
@@ -61,7 +61,7 @@ using System.Runtime.InteropServices;
         It 'Should rewrite minimal AssemblyInfo.cs' {
             $filename = (New-TemporaryFile).FullName
             $initialAssemblyInfo | Out-File $filename -Encoding UTF8
-            Rewrite-AssemblyInfo -ProjectName 'ClassLibrary1' -ProductName 'SQL Dummy' -RootNamespace 'ClassLibrary1' -AssemblyInfoPath $filename -Version '1.2.3.456' -InfoVersion '1.2.3.456-branch-suffix' -Year '2019'
+            Rewrite-AssemblyInfo -ProjectName 'ClassLibrary1' -ProductName 'SQL Dummy' -RootNamespace 'ClassLibrary1' -AssemblyInfoPath $filename -Version '1.2.3.456' -AssemblyVersion '1.0.0.0' -InfoVersion '1.2.3.456-branch-suffix' -Year '2019'
             $actualOutput = Get-Content $filename -Raw -Encoding UTF8
             Remove-Item $filename
             $actualOutput | Should Be $expectedOutput

--- a/Tests/Rewrite-AssemblyInfos.Tests.ps1
+++ b/Tests/Rewrite-AssemblyInfos.Tests.ps1
@@ -111,7 +111,7 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible(false)]
 
-[assembly: AssemblyVersion("1.2.3.456")]
+[assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.2.3.456")]
 [assembly: AssemblyInformationalVersion("1.2.3.456-branch-name")]
 
@@ -127,7 +127,7 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible(false)]
 
-[assembly: AssemblyVersion("1.2.3.456")]
+[assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.2.3.456")]
 [assembly: AssemblyInformationalVersion("1.2.3.456-branch-name")]
 
@@ -143,7 +143,7 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible(false)]
 
-[assembly: AssemblyVersion("2.3.4.567")]
+[assembly: AssemblyVersion("2.0.0.0")]
 [assembly: AssemblyFileVersion("2.3.4.567")]
 [assembly: AssemblyInformationalVersion("2.3.4.567-branch-name")]
 
@@ -154,7 +154,7 @@ using System.Runtime.InteropServices;
     $versionOverrides = @{
         $differentVersionProjectName = [Version] '2.3.4.567'
     }
-    Rewrite-AssemblyInfos -SolutionFile $solutionFile -ProductName 'SQL Dummy' -Version '1.2.3.456' -InfoVersionSuffix '-branch-name' -Year '2019' -ProductNameOverrides $productNameOverrides -VersionOverrides $versionOverrides
+    Rewrite-AssemblyInfos -SolutionFile $solutionFile -ProductName 'SQL Dummy' -Version '1.2.3.456' -AssemblyVersionMajorOnly -InfoVersionSuffix '-branch-name' -Year '2019' -ProductNameOverrides $productNameOverrides -VersionOverrides $versionOverrides
     It 'AssemblyInfo for normal project should be rewritten normally' {
         $actualNormalProjectAssemblyInfo = Get-Content $normalProjectAssemblyInfo -Raw -Encoding UTF8
         $actualNormalProjectAssemblyInfo | Should Be $expectedNormalProjectAssemblyInfo

--- a/build.ps1
+++ b/build.ps1
@@ -73,7 +73,7 @@ task GenerateVersionInfo ImportModules, {
 # Synopsis: Create the RedGate.Build nuget package
 task Pack GenerateVersionInfo, {
 
-    $escapedReleaseNotes = $Notes.Content -replace '"','\"'
+    $escapedReleaseNotes = $Notes.Content -replace '"','\"' -replace '`',''
 
     exec {
         & $NugetExe pack $PSScriptRoot\RedGate.Build.nuspec `


### PR DESCRIPTION
For semantically versioned assemblies, we want AssemblyVersion to just have a major version. So, I've introduced an `-AssemblyVersionMajorOnly` flag to `Rewrite-AssemblyInfos`.